### PR TITLE
fix bug

### DIFF
--- a/flexsearch.js
+++ b/flexsearch.js
@@ -1883,7 +1883,7 @@
 
                                 for(let z = 0; z < (resolution - threshold); z++){
 
-                                    if((map_value = map[z][value])){
+                                    if((map_value = (map[z] && map[z][value]))){
 
                                         map_check[count++] = map_value;
                                         map_found = true;


### PR DESCRIPTION
When the threshold of search options is smaller than the threshold of create options, there is a exception thrown.
I think that ignoring it is better than throw exception.