### PR TITLE
Fix generics on Typscript typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -9,7 +9,7 @@ declare module "flexsearch" {
     init(options: CreateOptions);
     info();
     add(o: T);
-    add(id: number, o: T);
+    add(id: number, o: string);
 
     // Result without pagination -> T[]
     search(query: string, options: number | SearchOptions, callback: (results: T[]) => void): void;
@@ -52,6 +52,11 @@ declare module "flexsearch" {
     result: T[]
   }
 
+  interface Document {
+      id: string;
+      field: any;
+  }
+
 
   export type CreateOptions = {
     profile?: IndexProfile;
@@ -67,6 +72,7 @@ declare module "flexsearch" {
     stemmer?: Stemmer | string | false;
     filter?: FilterFn | string | false;
     rtl?: boolean;
+    doc?: Document;
   };
 
 //   limit	number	Sets the limit of results.

--- a/index.d.ts
+++ b/index.d.ts
@@ -7,17 +7,30 @@ declare module "flexsearch" {
 
     init();
     init(options: CreateOptions);
+    info();
+    add(o: T);
     add(id: number, o: T);
-    search(query: string, options: number | SearchOptions, callback: (results: SearchResults<T>) => void): void;
-    search(query: string, options?: number | SearchOptions): Promise<SearchResults<T>>;
-    search(options: SearchOptions & {query: string}, callback: (results: SearchResults<T>) => void): void;
-    search(options: SearchOptions & {query: string}): Promise<SearchResults<T>>;
+
+    // Result without pagination -> T[]
+    search(query: string, options: number | SearchOptions, callback: (results: T[]) => void): void;
+    search(query: string, options?: number | SearchOptions): Promise<T[]>;
+    search(options: SearchOptions & {query: string}, callback: (results: T[]) => void): void;
+    search(options: SearchOptions & {query: string}): Promise<T[]>;
+
+    // Result with pagination -> SearchResults<T>
+    search(query: string, options: number | SearchOptions & { page?: boolean | Cursor}, callback: (results: SearchResults<T>) => void): void;
+    search(query: string, options?: number | SearchOptions & { page?: boolean | Cursor}): Promise<SearchResults<T>>;
+    search(options: SearchOptions & {query: string, page?: boolean | Cursor}, callback: (results: SearchResults<T>) => void): void;
+    search(options: SearchOptions & {query: string, page?: boolean | Cursor}): Promise<SearchResults<T>>;
+
+
     update(id: number, o: T);
     remove(id: number);
     clear();
     destroy();
     addMatcher(matcher: Matcher);
-    where(whereFn: (o: T) => boolean): SearchResult<T>[];
+
+    where(whereFn: (o: T) => boolean): T[];
     where(whereObj: {[key: string]: string});
     encode(str: string): string;
     export(): string;
@@ -25,22 +38,20 @@ declare module "flexsearch" {
   }
 
   interface SearchOptions {
-      limit?: number,   
-      suggest?: boolean,
-      where?: {[key: string]: string},
-      field?: string | string[],
-      bool?: "and" | "or" | "not"
-      page?: boolean | Cursor;
-      //TODO: Sorting
+    limit?: number,
+    suggest?: boolean,
+    where?: {[key: string]: string},
+    field?: string | string[],
+    bool?: "and" | "or" | "not"
+    //TODO: Sorting
   }
 
   interface SearchResults<T> {
-      page?: Cursor,
-      next?: Cursor,
-      result: SearchResult[]
+    page?: Cursor,
+    next?: Cursor,
+    result: T[]
   }
 
-  type SearchResult = number;
 
   export type CreateOptions = {
     profile?: IndexProfile;
@@ -76,7 +87,7 @@ declare module "flexsearch" {
   type Cursor = string;
 
   export default class FlexSearch {
-    static create(options?: CreateOptions): Index;
+    static create<T>(options?: CreateOptions): Index<T>;
     static registerMatcher(matcher: Matcher);
     static registerEncoder(name: string, encoder: EncoderFn);
     static registerLanguage(lang: string, options: { stemmer?: Stemmer; filter?: string[] });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flexsearch",
-  "version": "0.6.30",
+  "version": "0.6.31",
   "description": "Next-Generation full text search library with zero dependencies.",
   "homepage": "https://github.com/nextapps-de/flexsearch/",
   "author": "Thomas Wilkerling",


### PR DESCRIPTION
The typescript typings has some problems.

1.  
![grafik](https://user-images.githubusercontent.com/10422951/62116500-91b91d80-b2ba-11e9-870c-7a217f851d13.png)   

2. the response from the search methods depends on the `page` option. So the response is a SearchResults or an array of the specified objects. 
(I duplicated the methods, removed the page from the `SearchOptions` and depending on the `page` property return an array of objects or a SearchResults object)

3. I added the info() method and the add(o: T) method 

4. added generic to create method  
![grafik](https://user-images.githubusercontent.com/10422951/62117121-a3e78b80-b2bb-11e9-8628-b2ea86d0ad34.png)


It would be nice if you take a look at this changes and merge them if they look good for you.




