### PR TITLE
Update results list for every query when using bool=or

### DIFF
--- a/flexsearch.js
+++ b/flexsearch.js
@@ -3451,7 +3451,7 @@
 
                                 // fill in during last round
 
-                                if(is_final_loop){
+                                if(is_final_loop || bool_or){
 
                                     // sadly the pointer could just applied here at the earliest
                                     // that's why pagination cannot reduce complexity actually


### PR DESCRIPTION
This fixes the following issue with using bool="or" with > 2 queries:

```
index.search([{ 
    field: "title",
    query: "foo",
    bool: "or"
},{ 
    field: "title",
    query: "bar",
    bool: "or"
},{ 
    field: "title",
    query: "test",
    bool: "or"
}]);
```
In this example, we only get results containing "foo" or "test".

The problem arose since only the first and last queries were being added to the results list; when using "or", we need results from every query to be added to the results list.