### PR TITLE
fix: Add typing in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,5 +74,6 @@
     "mocha-phantomjs": "^4.1.0",
     "nyc": "^14.1.1",
     "phantomjs-prebuilt": "^2.1.16"
-  }
+  },
+  "types": "index.d.ts"
 }


### PR DESCRIPTION
Typescript cannot find typings for `flexsearch`, this PR aims to fix this.