### PR TITLE
Fixed duplicated entries in intersect for multiple query results

### DIFF
--- a/flexsearch.js
+++ b/flexsearch.js
@@ -3461,6 +3461,7 @@
                                     if(!pointer_count || (--pointer_count < count)){
 
                                         result[count++] = tmp;
+                                        check[index] = z + 1; // add the entry to the existing results in case of multiple queries with an or clause
 
                                         if(limit && (count === limit)){
 


### PR DESCRIPTION
This fixes correctly the change done in https://github.com/nextapps-de/flexsearch/pull/141
In https://github.com/nextapps-de/flexsearch/pull/141 we were adding all the entries in case of multiple queries results in or, but without adding them to the map of the existing entries, so no checks were performed and possible duplicates could have been added.