### PR TITLE
Fix link to elasticlunr so site will work.

### DIFF
--- a/test/matching.html
+++ b/test/matching.html
@@ -217,7 +217,7 @@
 </div>
 <script src="../dist/flexsearch.min.js"></script>
 <script src="https://cdn.jsdelivr.net/gh/nextapps-de/bulksearch@master/bulksearch.min.js"></script>
-<script src="https://cdn.jsdelivr.net/gh/weixsong/elasticlunr.js@master/example/elasticlunr.min.js"></script>
+<script src="https://cdn.jsdelivr.net/gh/weixsong/elasticlunr.js@0.9.6/example/elasticlunr.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/lunr@2.1.6/lunr.min.js"></script>
 <script src="https://cdn.jsdelivr.net/gh/kbrsh/wade@master/dist/wade.min.js"></script>
 <script src="https://cdn.jsdelivr.net/gh/krisk/Fuse@3.0.4/dist/fuse.min.js"></script>


### PR DESCRIPTION
elasticlunr minified dist file is no longer in the base github repo, so we need to pin to a specific release version instead.  This is the same version as used in benchmark.html.

Fix for issue #167 .