### PR TITLE
types: Fix types for strict setting in tsconfig.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,15 +1,13 @@
 declare module "flexsearch" {
   interface Index<T> {
-    //TODO: Chaining
     readonly id: string;
     readonly index: string;
     readonly length: number;
 
-    init();
-    init(options: CreateOptions);
-    info();
-    add(o: T);
-    add(id: number, o: string);
+    init(options?: CreateOptions): Index<T>;
+    info(): void;
+    add(item: T): Index<T>;
+    add(id: number | string, stringContent: string): Index<T>;
 
     // Result without pagination -> T[]
     search(query: string, options: number | SearchOptions, callback: (results: T[]) => void): void;
@@ -24,17 +22,17 @@ declare module "flexsearch" {
     search(options: SearchOptions & {query: string, page?: boolean | Cursor}): Promise<SearchResults<T>>;
 
 
-    update(id: number, o: T);
-    remove(id: number);
-    clear();
-    destroy();
-    addMatcher(matcher: Matcher);
+    update(id: number, o: T): Index<T>;
+    remove(id: number): Index<T>;
+    clear(): Index<T>;
+    destroy(): Index<T>;
+    addMatcher(matcher: Matcher): Index<T>;
 
     where(whereFn: (o: T) => boolean): T[];
-    where(whereObj: {[key: string]: string});
+    where(whereObj: {[key: string]: string}): T[];
     encode(str: string): string;
     export(): string;
-    import(exported: string);
+    import(exported: string): void;
   }
 
   interface SearchOptions {
@@ -94,10 +92,10 @@ declare module "flexsearch" {
 
   export default class FlexSearch {
     static create<T>(options?: CreateOptions): Index<T>;
-    static registerMatcher(matcher: Matcher);
-    static registerEncoder(name: string, encoder: EncoderFn);
-    static registerLanguage(lang: string, options: { stemmer?: Stemmer; filter?: string[] });
-    static encode(name: string, str: string);
+    static registerMatcher(matcher: Matcher): Index<T>;
+    static registerEncoder(name: string, encoder: EncoderFn): Index<T>;
+    static registerLanguage(lang: string, options: { stemmer?: Stemmer; filter?: string[] }): Index<T>;
+    static encode(name: string, str: string): string;
   }
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -92,9 +92,9 @@ declare module "flexsearch" {
 
   export default class FlexSearch {
     static create<T>(options?: CreateOptions): Index<T>;
-    static registerMatcher(matcher: Matcher): Index<T>;
-    static registerEncoder(name: string, encoder: EncoderFn): Index<T>;
-    static registerLanguage(lang: string, options: { stemmer?: Stemmer; filter?: string[] }): Index<T>;
+    static registerMatcher<T>(matcher: Matcher): Index<T>;
+    static registerEncoder<T>(name: string, encoder: EncoderFn): Index<T>;
+    static registerLanguage<T>(lang: string, options: { stemmer?: Stemmer; filter?: string[] }): Index<T>;
     static encode(name: string, str: string): string;
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "email": "info@nextapps.de"
   },
   "main": "dist/flexsearch.node.js",
+  "types": "index.d.ts",
   "browser": "dist/flexsearch.min.js",
   "preferGlobal": false,
   "bin": {},


### PR DESCRIPTION
I have added all return types to index.d.ts which caused trouble when lib check and strict are enabled.
Also, I have updated add method which accepts iterable. 

Tested with the latest typescript.

Fix: #173 , #161 