### PR TITLE
Add missing annotations to index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,62 +1,86 @@
 declare module "flexsearch" {
-  interface Index<T> {
-    //TODO: Chaining
+  export interface Index<T> {
     readonly id: string;
     readonly index: string;
     readonly length: number;
 
-    init();
-    init(options: CreateOptions);
-    info();
-    add(o: T);
-    add(id: number, o: string);
+    init(options?: CreateOptions): this;
+    info(): {
+      id: any;
+      items: any;
+      cache: any;
+      matcher: number;
+      worker: any;
+      threshold: any;
+      depth: any;
+      resolution: any;
+      contextual: boolean;
+    };
+    add(o: T): this;
+    add(id: number, o: string): this;
 
     // Result without pagination -> T[]
-    search(query: string, options: number | SearchOptions, callback: (results: T[]) => void): void;
+    search(
+      query: string,
+      options: number | SearchOptions,
+      callback: (results: T[]) => void
+    ): void;
     search(query: string, options?: number | SearchOptions): Promise<T[]>;
-    search(options: SearchOptions & {query: string}, callback: (results: T[]) => void): void;
-    search(options: SearchOptions & {query: string}): Promise<T[]>;
+    search(
+      options: SearchOptions & { query: string },
+      callback: (results: T[]) => void
+    ): void;
+    search(options: SearchOptions & { query: string }): Promise<T[]>;
 
     // Result with pagination -> SearchResults<T>
-    search(query: string, options: number | SearchOptions & { page?: boolean | Cursor}, callback: (results: SearchResults<T>) => void): void;
-    search(query: string, options?: number | SearchOptions & { page?: boolean | Cursor}): Promise<SearchResults<T>>;
-    search(options: SearchOptions & {query: string, page?: boolean | Cursor}, callback: (results: SearchResults<T>) => void): void;
-    search(options: SearchOptions & {query: string, page?: boolean | Cursor}): Promise<SearchResults<T>>;
+    search(
+      query: string,
+      options: number | (SearchOptions & { page?: boolean | Cursor }),
+      callback: (results: SearchResults<T>) => void
+    ): void;
+    search(
+      query: string,
+      options?: number | (SearchOptions & { page?: boolean | Cursor })
+    ): Promise<SearchResults<T>>;
+    search(
+      options: SearchOptions & { query: string; page?: boolean | Cursor },
+      callback: (results: SearchResults<T>) => void
+    ): void;
+    search(
+      options: SearchOptions & { query: string; page?: boolean | Cursor }
+    ): Promise<SearchResults<T>>;
 
+    update(id: number, o: T): this;
+    remove(id: number): this;
+    clear(): this;
+    destroy(): this;
+    addMatcher(matcher: Matcher): this;
 
-    update(id: number, o: T);
-    remove(id: number);
-    clear();
-    destroy();
-    addMatcher(matcher: Matcher);
-
-    where(whereFn: (o: T) => boolean): T[];
-    where(whereObj: {[key: string]: string});
+    where(whereObj: { [key: string]: string } | ((o: T) => boolean)): T[];
     encode(str: string): string;
     export(): string;
-    import(exported: string);
+    import(exported: string): this;
   }
 
   interface SearchOptions {
-    limit?: number,
-    suggest?: boolean,
-    where?: {[key: string]: string},
-    field?: string | string[],
-    bool?: "and" | "or" | "not"
+    limit?: number;
+    suggest?: boolean;
+    where?: { [key: string]: string };
+    field?: string | string[];
+    bool?: "and" | "or" | "not";
     //TODO: Sorting
   }
 
   interface SearchResults<T> {
-    page?: Cursor,
-    next?: Cursor,
-    result: T[]
+    page?: Cursor;
+    next?: Cursor;
+    result: T[];
   }
 
   interface Document {
-      id: string;
-      field: any;
+    id: string;
+    field: any;
   }
-
 
   export type CreateOptions = {
     profile?: IndexProfile;
@@ -70,34 +94,43 @@ declare module "flexsearch" {
     threshold?: false | number;
     resolution?: number;
     stemmer?: Stemmer | string | false;
-    filter?: FilterFn | string | false;
+    filter?: FilterFn | string | false;
     rtl?: boolean;
     doc?: Document;
   };
 
-//   limit	number	Sets the limit of results.
-// suggest	true, false	Enables suggestions in results.
-// where	object	Use a where-clause for non-indexed fields.
-// field	string, Array<string>	Sets the document fields which should be searched. When no field is set, all fields will be searched. Custom options per field are also supported.
-// bool	"and", "or"	Sets the used logical operator when searching through multiple fields.
-// page	true, false, cursor	Enables paginated results.
+  //   limit	number	Sets the limit of results.
+  // suggest	true, false	Enables suggestions in results.
+  // where	object	Use a where-clause for non-indexed fields.
+  // field	string, Array<string>	Sets the document fields which should be searched. When no field is set, all fields will be searched. Custom options per field are also supported.
+  // bool	"and", "or"	Sets the used logical operator when searching through multiple fields.
+  // page	true, false, cursor	Enables paginated results.
 
-  type IndexProfile = "memory" | "speed" | "match" | "score" | "balance" | "fast";
+  type IndexProfile =
+    | "memory"
+    | "speed"
+    | "match"
+    | "score"
+    | "balance"
+    | "fast";
   type DefaultTokenizer = "strict" | "forward" | "reverse" | "full";
   type TokenizerFn = (str: string) => string[];
   type DefaultEncoder = "icase" | "simple" | "advanced" | "extra" | "balance";
   type EncoderFn = (str: string) => string;
-  type Stemmer = {[key: string]: string};
-  type Matcher = {[key: string]: string};
+  type Stemmer = { [key: string]: string };
+  type Matcher = { [key: string]: string };
   type FilterFn = (str: string) => boolean;
   type Cursor = string;
 
   export default class FlexSearch {
     static create<T>(options?: CreateOptions): Index<T>;
-    static registerMatcher(matcher: Matcher);
-    static registerEncoder(name: string, encoder: EncoderFn);
-    static registerLanguage(lang: string, options: { stemmer?: Stemmer; filter?: string[] });
-    static encode(name: string, str: string);
+    static registerMatcher(matcher: Matcher): typeof FlexSearch;
+    static registerEncoder(name: string, encoder: EncoderFn): typeof FlexSearch;
+    static registerLanguage(
+      lang: string,
+      options: { stemmer?: Stemmer; filter?: string[] }
+    ): typeof FlexSearch;
+    static encode(name: string, str: string): string;
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "test-coverage": "nyc --reporter=html --reporter=text mocha --timeout=3000 test/test.js",
     "test": "npm run test-develop && npm run test-production && npm run test-light && npm run test-browser && npm run test-coverage",
     "coverage": "nyc report --reporter=text-lcov | coveralls",
-    "update": "npm install chai@latest && npm install codacy-coverage@latest && npm install coveralls@latest && npm install nyc@latest && npm install google-closure-compiler@nightly && npm install mocha@latest && npm install mocha-lcov-reporter@latest && npm install mocha-phantomjs@latest && npm install phantomjs-prebuilt@latest"
+    "update": "npm install chai@latest && npm install codacy-coverage@latest && npm install coveralls@latest && npm install nyc@latest && npm install google-closure-compiler@nightly && npm install mocha@latest && npm install mocha-lcov-reporter@latest && npm install mocha-phantomjs@latest && npm install phantomjs-prebuilt@latest",
+    "typecheck": "npx tsc --noEmit --strict index.d.ts"
   },
   "nyc": {
     "per-file": true,

--- a/package.json
+++ b/package.json
@@ -74,5 +74,6 @@
     "mocha-phantomjs": "^4.1.0",
     "nyc": "^14.1.1",
     "phantomjs-prebuilt": "^2.1.16"
-  }
+  },
+  "types": "index.d.ts"
 }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "main": "dist/flexsearch.node.js",
   "browser": "dist/flexsearch.min.js",
+  "types": "index.d.ts",
   "preferGlobal": false,
   "bin": {},
   "repository": {
@@ -75,6 +76,5 @@
     "mocha-phantomjs": "^4.1.0",
     "nyc": "^14.1.1",
     "phantomjs-prebuilt": "^2.1.16"
-  },
-  "types": "index.d.ts"
+  }
 }


### PR DESCRIPTION
Hi :wave:

I added missing annotations to `index.d.ts` to make it usable in TypeScript projects with `strictLibChecks: true`.
I've also added a small script to package.json to test it, and included @itkg-mbaumann's PR, because my changes are not really useful without his.