### PR TITLE
Adds missing TypeScript definitions file to the package.json "files" and "types" entries

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,8 +50,10 @@
     "task/**",
     "README.md",
     "CHANGELOG.md",
-    "LICENSE"
+    "LICENSE",
+    "index.d.ts"
   ],
+  "types": "index.d.ts",
   "readme": "README.md",
   "devDependencies": {
     "babel-cli": "^6.26.0",


### PR DESCRIPTION
Adds missing TypeScript definitions file to the package.json "files" and "types" entries in order to make them available in the published npm package.