### PR TITLE
Fix enriched results after importing Document

### DIFF
--- a/src/serialize.js
+++ b/src/serialize.js
@@ -169,12 +169,14 @@ export function exportDocument(callback, self, field, index_doc, index){
 
                 key = "tag";
                 data = this.tagindex;
+                field = null;
                 break;
 
             case 2:
 
                 key = "store";
                 data = this.store;
+                field = null;
                 break;
 
             // case 3:


### PR DESCRIPTION
When exporting `store` and `tag` objects of Document, unset the `field` to prevent them from being scoped to an index in the `importDocument` method.

Fixes #358