### PR TITLE
Correct type of id argument in index add method

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -17,7 +17,7 @@ declare module "flexsearch" {
       contextual: boolean;
     };
     add(o: T): this;
-    add(id: number, o: string): this;
+    add(id: number | string, o: string): this;
 
     // Result without pagination -> T[]
     search(


### PR DESCRIPTION
Correct type of id argument in index add method to include string type as it is in the [source](https://github.com/nextapps-de/flexsearch/blob/master/src/index.js#L125)