### PR TITLE
Update docs  for usage with ESM / ES6

### DIFF
--- a/README.md
+++ b/README.md
@@ -445,12 +445,12 @@ There are 3 types of indexes:
 
 The most of you probably need just one of them according to your scenario.
 
-### ES6 Modules (Browser):
+### ESM / ES6 Modules (Browser:
 
 ```js
-import Index from "./index.js";
-import Document from "./document.js";
-import WorkerIndex from "./worker/index.js";
+import Index from "flexsearch/dist/module";
+import Worker from "flexsearch/dist/module/worker";
+import Doc from "flexsearch/dist/module/document";
 
 const index = new Index(options);
 const document = new Document(options);


### PR DESCRIPTION
The existing docs show a relative path, not the actual npm module bundle path.

I believe this should be correct for ESM/ES6 type environments and will hopefully prevent confusion as found in #341 etc.