### PR TITLE
add nikola flexsearch plugin to Plugins (extern projects)

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Plugins (extern projects):
 - React: https://github.com/angeloashmore/react-use-flexsearch
 - Vue: https://github.com/Noction/vue-use-flexsearch
 - Gatsby: https://www.gatsbyjs.org/packages/gatsby-plugin-flexsearch/
+- Nikola: https://plugins.getnikola.com/v8/flexsearch_plugin/
 
 ### Get Latest
 


### PR DESCRIPTION
Hi, 

I added a new plugin to [Nikola](https://getnikola.com/) [MR](https://github.com/getnikola/plugins/pull/441) that uses Flexsearch.

The plugin page is https://plugins.getnikola.com/v8/flexsearch_plugin/

I thought it would be interesting to list it here. 

Best, 

Diego