### PR TITLE
Fix tokenizer option examples in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1008,28 +1008,28 @@ Try to choose the most upper of these tokenizer which covers your requirements:
     <tr>
         <td><code>"strict"</code><br><code>"exact"</code><br><code>"default"</code></td>
         <td>index the full term</td>
-        <td><a>foobar</a></td>
+        <td><code>foobar</code></td>
         <td>1</td>
     </tr>
     <tr></tr>
     <tr>
         <td><code>"forward"</code></td>
         <td>index term in forward direction (supports right-to-left by Index option <code>rtl: true</code>)</td>
-        <td><a>fo</a>obar<br><a>foob</a>ar<br></td>
+        <td><code>fo</code>obar<br><code>foob</code>ar<br></td>
         <td>n</td>
     </tr>
     <tr></tr>
     <tr>
         <td><code>"reverse"</code><br><code>"bidirectional"</code></td>
         <td>index term in both directions</td>
-        <td><a>fo</a>obar<br><a>foob</a>ar<br>foob<a>ar</a><br>fo<a>obar</a></td>
+        <td><code>fo</code>obar<br><code>foob</code>ar<br>foob<code>ar</code><br>fo<code>obar</code></td>
         <td>2n - 1</td>
     </tr>
     <tr></tr>
     <tr>
         <td><code>"full"</code></td>
         <td>index every consecutive partial</td>
-        <td>fo<a>oba</a>r<br>f<a>oob</a>ar</td>
+        <td>fo<code>oba</code>r<br>f<code>oob</code>ar</td>
         <td>n * (n - 1)</td>
     </tr>
 </table>


### PR DESCRIPTION
Quick fix to the examples for options in Tokenizer section. 

Before:

![image](https://github.com/user-attachments/assets/7505c567-ddaf-4759-a24c-e73327f5235d)

After:

![image](https://github.com/user-attachments/assets/0b59ef24-c035-4d8e-b597-0dbc384d9c51)
