### PR TITLE
fix: remove imports from lang files

### DIFF
--- a/package.json
+++ b/package.json
@@ -142,5 +142,6 @@
       "type": "bountysource",
       "url": "https://salt.bountysource.com/teams/ts-thomas"
     }
-  ]
+  ],
+  "packageManager": "pnpm@9.15.9+sha512.68046141893c66fad01c079231128e9afb89ef87e2691d69e4d40eee228988295fd4682181bae55b58418c3a253bde65a505ec7c5f9403ece5cc3cd37dcf2531"
 }

--- a/src/lang/de.js
+++ b/src/lang/de.js
@@ -1,5 +1,3 @@
-import { EncoderOptions } from "../type.js";
-
 /**
  * Filter are also known as "stopwords", they completely filter out words from being indexed.
  * Source: http://www.ranks.nl/stopwords
@@ -190,7 +188,7 @@ const map = new Map([
 ]);
 
 /**
- * @type EncoderOptions
+ * @type {import('../type.js').EncoderOptions}
  */
 const options = {
     prepare: function(str){

--- a/src/lang/en.js
+++ b/src/lang/en.js
@@ -1,5 +1,3 @@
-import { EncoderOptions } from "../type.js";
-
 // todo filter out minlength
 
 /**
@@ -309,7 +307,7 @@ export const stemmer = new Map([
 // ]);
 
 /**
- * @type EncoderOptions
+ * @type {import('../type.js').EncoderOptions}
  */
 const options = {
     prepare: function(str){

--- a/src/lang/fr.js
+++ b/src/lang/fr.js
@@ -1,5 +1,3 @@
-import { EncoderOptions } from "../type.js";
-
 /**
  * http://www.ranks.nl/stopwords
  * http://snowball.tartarus.org/algorithms/french/stop.txt
@@ -205,7 +203,7 @@ export const stemmer = new Map([
 ]);
 
 /**
- * @type EncoderOptions
+ * @type {import('../type.js').EncoderOptions}
  */
 const options = {
     prepare: function(str){


### PR DESCRIPTION
The imports where done to have type checks available. Since the
code is JS with JSDoc, it's better to use JSDoc imports instead.
There do not have an impact on bundling/loading but does work
for typechecking as well.
