### PR TITLE
Better typescript type inference

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -217,9 +217,9 @@ declare module "flexsearch" {
     /* Index Search                     */
     /************************************/
 
-    type DefaultSearchResults = Id[];
+    export type DefaultSearchResults = Id[];
     type IntermediateSearchResults = Array<Id[]>;
-    type SearchResults = DefaultSearchResults | Resolver;
+    type SearchResults<D extends DocumentData = DocumentData> = DefaultSearchResults | Resolver<D>;
 
     /**
      * **Document:**
@@ -606,14 +606,14 @@ declare module "flexsearch" {
         enrich?: boolean;
     };
 
-    type ResolverOptions = DefaultResolve & {
-        index?: Index | Document;
-        pluck?: FieldName;
-        field?: FieldName;
-        and?: ResolverOptions | Array<ResolverOptions>;
-        or?: ResolverOptions | Array<ResolverOptions>;
-        xor?: ResolverOptions | Array<ResolverOptions>;
-        not?: ResolverOptions | Array<ResolverOptions>;
+    type ResolverOptions<D extends DocumentData = DocumentData> = DefaultResolve & {
+        index?: Index | Document<D>;
+        pluck?: FieldName<D>;
+        field?: FieldName<D>;
+        and?: ResolverOptions<D> | Array<ResolverOptions<D>>;
+        or?: ResolverOptions<D> | Array<ResolverOptions<D>>;
+        xor?: ResolverOptions<D> | Array<ResolverOptions<D>>;
+        not?: ResolverOptions<D> | Array<ResolverOptions<D>>;
         boost?: number;
         suggest?: boolean;
         resolve?: boolean;
@@ -660,7 +660,7 @@ declare module "flexsearch" {
         addReplacer(match: string | RegExp, replace: string): this;
     }
 
-    export class Resolver {
+    export class Resolver<D extends DocumentData = DocumentData> {
         result: IntermediateSearchResults;
 
         constructor(options?: ResolverOptions | IntermediateSearchResults);
@@ -679,7 +679,7 @@ declare module "flexsearch" {
 
         boost(boost: number): this;
 
-        resolve(options?: DefaultResolve): SearchResults;
+        resolve(options?: DefaultResolve): SearchResults<D>;
     }
 
     class StorageInterface {

--- a/index.d.ts
+++ b/index.d.ts
@@ -217,9 +217,9 @@ declare module "flexsearch" {
     /* Index Search                     */
     /************************************/
 
-    export type DefaultSearchResults = Id[];
+    type DefaultSearchResults = Id[];
     type IntermediateSearchResults = Array<Id[]>;
-    type SearchResults<D extends DocumentData = DocumentData> = DefaultSearchResults | Resolver<D>;
+    type SearchResults = DefaultSearchResults | Resolver;
 
     /**
      * **Document:**
@@ -606,14 +606,14 @@ declare module "flexsearch" {
         enrich?: boolean;
     };
 
-    type ResolverOptions<D extends DocumentData = DocumentData> = DefaultResolve & {
-        index?: Index | Document<D>;
-        pluck?: FieldName<D>;
-        field?: FieldName<D>;
-        and?: ResolverOptions<D> | Array<ResolverOptions<D>>;
-        or?: ResolverOptions<D> | Array<ResolverOptions<D>>;
-        xor?: ResolverOptions<D> | Array<ResolverOptions<D>>;
-        not?: ResolverOptions<D> | Array<ResolverOptions<D>>;
+    type ResolverOptions = DefaultResolve & {
+        index?: Index | Document;
+        pluck?: FieldName;
+        field?: FieldName;
+        and?: ResolverOptions | Array<ResolverOptions>;
+        or?: ResolverOptions | Array<ResolverOptions>;
+        xor?: ResolverOptions | Array<ResolverOptions>;
+        not?: ResolverOptions | Array<ResolverOptions>;
         boost?: number;
         suggest?: boolean;
         resolve?: boolean;
@@ -660,7 +660,7 @@ declare module "flexsearch" {
         addReplacer(match: string | RegExp, replace: string): this;
     }
 
-    export class Resolver<D extends DocumentData = DocumentData> {
+    export class Resolver {
         result: IntermediateSearchResults;
 
         constructor(options?: ResolverOptions | IntermediateSearchResults);
@@ -679,7 +679,7 @@ declare module "flexsearch" {
 
         boost(boost: number): this;
 
-        resolve(options?: DefaultResolve): SearchResults<D>;
+        resolve(options?: DefaultResolve): SearchResults;
     }
 
     class StorageInterface {

--- a/index.d.ts
+++ b/index.d.ts
@@ -108,8 +108,8 @@ declare module "flexsearch" {
         ? {
             [K in keyof D]: K extends string
                 ? D[K] extends Array<infer U>
-                    ? `${K}` | `${K}[]:${FieldName<U> & string}`
-                    : K | `${K}:${FieldName<D[K]> & string}`
+                    ? `${ K }` | `${ K }[]:${ FieldName<U> & string }`
+                    : K | `${ K }:${ FieldName<D[K]> & string }`
                 : never
         }[keyof D]
         : never
@@ -219,7 +219,7 @@ declare module "flexsearch" {
 
     type DefaultSearchResults = Id[];
     type IntermediateSearchResults = Array<Id[]>;
-    type SearchResults = DefaultSearchResults | Resolver;
+    type SearchResults<R extends boolean = false> = R extends true ? Resolver : DefaultSearchResults;
 
     /**
      * **Document:**
@@ -242,13 +242,15 @@ declare module "flexsearch" {
 
         remove(id: Id): this | Promise<this>;
 
-        search(query: string, options?: Limit | SearchOptions): SearchResults | Promise<SearchResults>;
-        search(query: string, limit: number, options: SearchOptions): SearchResults | Promise<SearchResults>;
-        search(options: SearchOptions): SearchResults | Promise<SearchResults>;
+        search(query: string, limit?: Limit): SearchResults | Promise<SearchResults>;
+        search<R extends boolean = false>(query: string, options?: SearchOptions<R>): SearchResults<R> | Promise<SearchResults<R>>;
+        search<R extends boolean = false>(query: string, limit: Limit, options: SearchOptions<R>): SearchResults<R> | Promise<SearchResults<R>>;
+        search<R extends boolean = false>(options: SearchOptions<R>): SearchResults<R> | Promise<SearchResults<R>>;
 
-        searchCache(query: string, options?: Limit | SearchOptions): SearchResults | Promise<SearchResults>;
-        searchCache(query: string, limit: number, options: SearchOptions): SearchResults | Promise<SearchResults>;
-        searchCache(options: SearchOptions): SearchResults | Promise<SearchResults>;
+        searchCache(query: string, limit?: Limit): SearchResults | Promise<SearchResults>;
+        searchCache<R extends boolean = false>(query: string, options?: Limit | SearchOptions<R>): SearchResults<R> | Promise<SearchResults<R>>;
+        searchCache<R extends boolean = false>(query: string, limit: Limit, options: SearchOptions<R>): SearchResults<R> | Promise<SearchResults<R>>;
+        searchCache<R extends boolean = false>(options: SearchOptions<R>): SearchResults<R> | Promise<SearchResults<R>>;
 
         // https://github.com/nextapps-de/flexsearch#check-existence-of-already-indexed-ids
         contain(id: Id): boolean | Promise<boolean>;
@@ -299,19 +301,24 @@ declare module "flexsearch" {
 
         searchAsync(
             query: string,
-            options?: Limit | SearchOptions,
+            limit?: Limit,
             callback?: AsyncCallback<SearchResults>,
         ): Promise<SearchResults>
-        searchAsync(
+        searchAsync<R extends boolean = false>(
+            query: string,
+            options?: SearchOptions<R>,
+            callback?: AsyncCallback<SearchResults<R>>,
+        ): Promise<SearchResults<R>>
+        searchAsync<R extends boolean = false>(
             query: string,
             limit: Limit,
-            options?: SearchOptions,
-            callback?: AsyncCallback<SearchResults>,
-        ): Promise<SearchResults>;
-        searchAsync(
-            options: SearchOptions,
-            callback?: AsyncCallback<SearchResults>,
-        ): Promise<SearchResults>;
+            options?: SearchOptions<R>,
+            callback?: AsyncCallback<SearchResults<R>>,
+        ): Promise<SearchResults<R>>;
+        searchAsync<R extends boolean = false>(
+            options: SearchOptions<R>,
+            callback?: AsyncCallback<SearchResults<R>>,
+        ): Promise<SearchResults<R>>;
     }
 
     /**

--- a/test/highlight.js
+++ b/test/highlight.js
@@ -195,7 +195,7 @@ if(!build_light) describe("Result Highlighting", function(){
         }]);
     });
 
-    it.only("Should have been highlighted results by boundary properly", function(){
+    it("Should have been highlighted results by boundary properly", function(){
 
         const data = [{
             "id": 1,

--- a/test/types.ts
+++ b/test/types.ts
@@ -1,20 +1,26 @@
-import { DefaultDocumentSearchResults, Document, Resolver } from "flexsearch";
+import {
+    DefaultDocumentSearchResults,
+    Document,
+    Index,
+    Worker,
+    Resolver,
+    StorageInterface,
+} from "flexsearch";
 import "../index";
 
-const document = new Document<{
-    title: string
-    description: string
-    tags: {
-        name: string
-        id: number
-    }[]
-}>({
-    document: {
-        index: ["tags"],
-    },
-});
-
 async function test() {
+    const document = new Document<{
+        title: string
+        description: string
+        tags: {
+            name: string
+            id: number
+        }[]
+    }>({
+        document: {
+            index: [ "tags" ],
+        },
+    });
     // The correct type
     const doc1 = await document.searchAsync({});
     const doc2: Resolver = await document.searchAsync({
@@ -35,6 +41,30 @@ async function test() {
     const docw2: DefaultDocumentSearchResults = await document.searchAsync({
         enrich: true,
     });
-    // ...
+    // Promise?
+    const documentNoWorker = new Document({});
+    const doc5 = documentNoWorker.search({}); // No Promise
+
+    const documentWorker = new Document({
+        worker: true,
+    });
+    const doc6 = await documentWorker.search({}) // Promise
+
+    const documentWorker2 = new Document({
+        worker: '...',
+    });
+    const doc7 = await documentWorker2.search({}) // Promise
+
+    const index = new Index({})
+    const idx = index.search({}) // No Promise
+
+    const worker =  new Worker()
+    const wkr = await worker.search({}) // Promise
+
+    const documentDb = new Document({
+        db: {} as unknown as StorageInterface
+    })
+
+    const doc8 = documentDb.search({}) // Promise
 }
 

--- a/test/types.ts
+++ b/test/types.ts
@@ -1,0 +1,16 @@
+import { Document } from 'flexsearch'
+import '../index'
+
+const document = new Document<{
+  title: string
+  description: string
+  tags: string[]
+}>({})
+
+async function test() {
+  const doc = await document.searchAsync('test', {
+    enrich: true,
+    pluck: 'test',
+  })
+}
+

--- a/test/types.ts
+++ b/test/types.ts
@@ -1,16 +1,33 @@
-import { Document } from 'flexsearch'
-import '../index'
+import { DefaultDocumentSearchResults, Document, Resolver } from "flexsearch";
+import "../index";
 
 const document = new Document<{
-  title: string
-  description: string
-  tags: string[]
-}>({})
+    title: string
+    description: string
+    tags: string[]
+}>({});
 
 async function test() {
-  const doc = await document.searchAsync('test', {
-    enrich: true,
-    pluck: 'test',
-  })
+    // The correct type
+    const doc1 = await document.searchAsync({});
+    const doc2: Resolver = await document.searchAsync({
+        resolve: true,
+    });
+    const doc3 = await document.searchAsync({
+        enrich: true,
+    });
+    const doc4 = await document.searchAsync({
+        enrich: true,
+        merge: true,
+    });
+    doc4[0].doc.title;
+    // The wrong type
+    // @ts-expect-error
+    const docw1: Resolver = await document.searchAsync({});
+    // @ts-expect-error
+    const docw2: DefaultDocumentSearchResults = await document.searchAsync({
+        enrich: true,
+    });
+    // ...
 }
 

--- a/test/types.ts
+++ b/test/types.ts
@@ -4,8 +4,15 @@ import "../index";
 const document = new Document<{
     title: string
     description: string
-    tags: string[]
-}>({});
+    tags: {
+        name: string
+        id: number
+    }[]
+}>({
+    document: {
+        index: ["tags"],
+    },
+});
 
 async function test() {
     // The correct type

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "target": "ESNext"
+  }
+}


### PR DESCRIPTION
## issue

#496 #396 

## Why

The meaning of this draft is to provide flexsearch with more comprehensive type inference and eliminate behavior that is inconsistent with expectations when used in typescript.

> 该草案存在的意义是为`flexsearch`提供更全面的类型推断，消除在typescript中使用时和预期不符的行为。

**To disambiguate, the following will use Chinese**

## 已完成

- 我在最大限度保留原风格的情况下格式化了整个index.d.ts文件，增加了可读性
- 为`Document`添加泛型，支持了文档内容的代码补全和静态类型检查
```ts
const document = new Document<{
    title: string
    description: string
    tags: string[]
}>({}); // Document<{ title: string; description: string; tags: string[] }>
const doc = await document.searchAsync({
    enrich: true,
    merge: true,
});
doc[0].doc // { title: string; description: string; tags: string[] }
```
- 为`Document`的查询方法(`search`, `searchAsync`, `searchCache`)，自动推断返回类型，不再返回联合类型，这一点非常重要且很有用
```ts
const doc1 = await document.searchAsync({
    enrich: true,
}); // EnrichedDocumentSearchResults<{ title: string; description: string; tags: string[] }>
const doc2 = await document.searchAsync({
    enrich: true,
    merge: true,
}); // MergedDocumentSearchResults<{ title: string; description: string; tags: string[] }>
```
- 为`Index`的`search`等方法添加同上的支持
- 为字段提供类型推断，包括`DocumentSearchOptions.field/index/pluck`和`DocumentDescriptor.field/index/tag/store`以及所有使用了`FieldName`的地方
```ts
const document = new Document<{
    title: string
    description: string
    tags: {
        name: string
        id: number
    }[]
}>({
    document: {
        index: ["tags"], // "description" | "title" | "tags" | "tags[]:name" | "tags[]:id"
    },
});
```
## 计划

- 为`Resolver`添加泛型

欢迎提出在类型方面的建议