### PR TITLE
fix: prevent DOM elements with id="process" from hijacking environment detection

### DIFF
--- a/task/build.js
+++ b/task/build.js
@@ -438,7 +438,7 @@ else (async function(){
         build = build.replace(/\(([a-z])=([a-z]).config\)&&\(([a-z])=([a-z])\)/, "($1=$2.config)&&($3=(await import($4))[\"default\"])");
 
         if(options["SUPPORT_WORKER"]){
-            build = build.replace("(function(self){'use strict';", "(function _f(self){'use strict';if(typeof module!=='undefined')self=module;else if(typeof process !== 'undefined')self=process;self._factory=_f;");
+            build = build.replace("(function(self){'use strict';", "(function _f(self){'use strict';if(typeof module!=='undefined')self=module;else if(typeof process !== 'undefined' && typeof process.env !== 'undefined')self=process;self._factory=_f;");
             //build = build.replace("(function(self){", "(function _f(self){if(typeof module!=='undefined')self=module;else if(typeof process !== 'undefined')self=process;self._factory=_f;");
         }
 


### PR DESCRIPTION
# Problem

Browsers implement named access on windows object, which means any DOM element with an `id` attribute can be accessed via `window.<id>`.

For example, if an attribute's `id` is `process`, like:

```html
<h2 id="process">Process</h2>
```

Then, `window.process` points to a DOM element instead of being `undefined`.

And FlexSearch's bundle entry point contains:

```javascript
if(typeof module!=='undefined')self=module;else if(typeof process !== 'undefined')self=process;self._factory=_f;
```

When `window.process` is a DOM element, `typeof process !== 'undefined'` is true, so `self` is assigned to the DOM element, causing FlexSearch initialization to fail.

# Fix

Add a `typeof process.env !== 'undefined'` to exclude DOM elements

```javascript
if(typeof module!=='undefined')self=module;else if(typeof process !== 'undefined' && typeof process.env !== 'undefined')self=process;self._factory=_f;
```