### PR TITLE
convert HTML tables to markdown in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Getting instant help by the DeepWiki AI assistant:
 <img src="https://img.shields.io/badge/typed-75%25-yellow"><!--<a target="_blank" href="https://github.com/nextapps-de/flexsearch/issues"><img src="https://img.shields.io/github/issues/nextapps-de/flexsearch.svg"></a>-->
 <a target="_blank" href="https://github.com/nextapps-de/flexsearch/blob/master/LICENSE"><img src="https://img.shields.io/npm/l/flexsearch.svg"></a>
 
-[Basic Start](#load-library) &ensp;&bull;&ensp; 
+[Basic Start](#load-library) &ensp;&bull;&ensp;
 [API Reference](#api-overview) &ensp;&bull;&ensp;
 [Encoder](doc/encoder.md) &ensp;&bull;&ensp;
 [Document Search](doc/document-search.md) &ensp;&bull;&ensp;
@@ -98,124 +98,21 @@ Benchmarks:
 The benchmark was measured in terms per seconds, higher values are better (except the test "Memory").
 The memory value refers to the amount of memory which was additionally allocated during search.<br>
 
-<table>
-    <tr></tr>
-    <tr>
-        <th>Library</th>
-        <th>Memory</th>
-        <th>Query: Single</th>
-        <th>Query: Multi</th>
-        <th>Query: Large</th>
-        <th>Query: Not Found</th>
-    </tr>
-    <tr>
-        <td>flexsearch</td>
-        <td align="right">16</td>
-        <td align="right">50955718</td>
-        <td align="right">11912730</td>
-        <td align="right">13981110</td>
-        <td align="right">51706499</td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td>jsii</td>
-        <td align="right">2188</td>
-        <td align="right">13847</td>
-        <td align="right">949559</td>
-        <td align="right">1635959</td>
-        <td align="right">3730307</td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td>wade</td>
-        <td align="right">980</td>
-        <td align="right">60473</td>
-        <td align="right">443214</td>
-        <td align="right">419152</td>
-        <td align="right">1239372</td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td>js-search</td>
-        <td align="right">237</td>
-        <td align="right">22982</td>
-        <td align="right">383775</td>
-        <td align="right">426609</td>
-        <td align="right">994803</td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td>minisearch</td>
-        <td align="right">4777</td>
-        <td align="right">30589</td>
-        <td align="right">191657</td>
-        <td align="right">5849</td>
-        <td align="right">304233</td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td>orama</td>
-        <td align="right">5355</td>
-        <td align="right">29445</td>
-        <td align="right">170231</td>
-        <td align="right">4454</td>
-        <td align="right">225491</td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td>elasticlunr</td>
-        <td align="right">3073</td>
-        <td align="right">14326</td>
-        <td align="right">48558</td>
-        <td align="right">101206</td>
-        <td align="right">95840</td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td>lunr</td>
-        <td align="right">2443</td>
-        <td align="right">11527</td>
-        <td align="right">51476</td>
-        <td align="right">88858</td>
-        <td align="right">103386</td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td>ufuzzy</td>
-        <td align="right">13754</td>
-        <td align="right">2799</td>
-        <td align="right">7788</td>
-        <td align="right">58544</td>
-        <td align="right">9557</td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td>bm25</td>
-        <td align="right">33963</td>
-        <td align="right">3903</td>
-        <td align="right">4777</td>
-        <td align="right">12657</td>
-        <td align="right">12471</td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td>fuzzysearch</td>
-        <td align="right">300147</td>
-        <td align="right">148</td>
-        <td align="right">229</td>
-        <td align="right">455</td>
-        <td align="right">276</td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td>fuse</td>
-        <td align="right">247107</td>
-        <td align="right">422</td>
-        <td align="right">321</td>
-        <td align="right">337</td>
-        <td align="right">329</td>
-    </tr>
-</table>
+| Library     | Memory | Query: Single | Query: Multi | Query: Large | Query: Not Found |
+|-------------|--------|---------------|--------------|--------------|------------------|
+| flexsearch  | 16     | 50955718      | 11912730     | 13981110     | 51706499         |
+| jsii        | 2188   | 13847         | 949559       | 1635959      | 3730307          |
+| wade        | 980    | 60473         | 443214       | 419152       | 1239372          |
+| js-search   | 237    | 22982         | 383775       | 426609       | 994803           |
+| minisearch  | 4777   | 30589         | 191657       | 5849         | 304233           |
+| orama       | 5355   | 29445         | 170231       | 4454         | 225491           |
+| elasticlunr | 3073   | 14326         | 48558        | 101206       | 95840            |
+| lunr        | 2443   | 11527         | 51476        | 88858        | 103386           |
+| ufuzzy      | 13754  | 2799          | 7788         | 58544        | 9557             |
+| bm25        | 33963  | 3903          | 4777         | 12657        | 12471            |
+| fuzzysearch | 300147 | 148           | 229          | 455          | 276              |
+| fuse        | 247107 | 422           | 321          | 337          | 329              |
+
 
 Run Comparison: <a href="https://nextapps-de.github.io/flexsearch/" target="_blank">Performance Benchmark "Gulliver's Travels"</a>
 
@@ -304,120 +201,28 @@ The **_dist_** folder is located in: `node_modules/flexsearch/dist/`
 <details>
 <summary>Download Builds</summary>
 <br>
-<table>
-    <tr></tr>
-    <tr>
-        <td>Build</td>
-        <td>File</td>
-        <td>CDN</td>
-    </tr>
-    <tr>
-        <td>flexsearch.bundle.min.js</td>
-        <td><a href="https://github.com/nextapps-de/flexsearch/raw/0.8.2/dist/flexsearch.bundle.min.js" target="_blank">Download</a></td>
-        <td><a href="https://cdn.jsdelivr.net/gh/nextapps-de/flexsearch@0.8.2/dist/flexsearch.bundle.min.js" target="_blank">https://cdn.jsdelivr.net/gh/nextapps-de/flexsearch@0.8.2/dist/flexsearch.bundle.min.js</a></td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td>flexsearch.bundle.debug.js</td>
-        <td><a href="https://github.com/nextapps-de/flexsearch/raw/0.8.2/dist/flexsearch.bundle.debug.js" target="_blank">Download</a></td>
-        <td><a href="https://cdn.jsdelivr.net/gh/nextapps-de/flexsearch@0.8.2/dist/flexsearch.bundle.debug.js" target="_blank">https://cdn.jsdelivr.net/gh/nextapps-de/flexsearch@0.8.2/dist/flexsearch.bundle.debug.js</a></td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td>flexsearch.bundle.module.min.js</td>
-        <td><a href="https://github.com/nextapps-de/flexsearch/raw/0.8.2/dist/flexsearch.bundle.module.min.js" target="_blank">Download</a></td>
-        <td><a href="https://cdn.jsdelivr.net/gh/nextapps-de/flexsearch@0.8.2/dist/flexsearch.bundle.module.min.js" target="_blank">https://cdn.jsdelivr.net/gh/nextapps-de/flexsearch@0.8.2/dist/flexsearch.bundle.module.min.js</a></td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td>flexsearch.bundle.module.debug.js</td>
-        <td><a href="https://github.com/nextapps-de/flexsearch/raw/0.8.2/dist/flexsearch.bundle.module.debug.js" target="_blank">Download</a></td>
-        <td><a href="https://cdn.jsdelivr.net/gh/nextapps-de/flexsearch@0.8.2/dist/flexsearch.bundle.module.debug.js" target="_blank">https://cdn.jsdelivr.net/gh/nextapps-de/flexsearch@0.8.2/dist/flexsearch.bundle.module.debug.js</a></td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td>flexsearch.compact.min.js</td>
-        <td><a href="https://github.com/nextapps-de/flexsearch/raw/0.8.2/dist/flexsearch.compact.min.js" target="_blank">Download</a></td>
-        <td><a href="https://cdn.jsdelivr.net/gh/nextapps-de/flexsearch@0.8.2/dist/flexsearch.compact.min.js" target="_blank">https://cdn.jsdelivr.net/gh/nextapps-de/flexsearch@0.8.2/dist/flexsearch.compact.min.js</a></td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td>flexsearch.compact.debug.js</td>
-        <td><a href="https://github.com/nextapps-de/flexsearch/raw/0.8.2/dist/flexsearch.compact.debug.js" target="_blank">Download</a></td>
-        <td><a href="https://cdn.jsdelivr.net/gh/nextapps-de/flexsearch@0.8.2/dist/flexsearch.compact.debug.js" target="_blank">https://cdn.jsdelivr.net/gh/nextapps-de/flexsearch@0.8.2/dist/flexsearch.compact.debug.js</a></td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td>flexsearch.compact.module.min.js</td>
-        <td><a href="https://github.com/nextapps-de/flexsearch/raw/0.8.2/dist/flexsearch.compact.module.min.js" target="_blank">Download</a></td>
-        <td><a href="https://cdn.jsdelivr.net/gh/nextapps-de/flexsearch@0.8.2/dist/flexsearch.compact.module.min.js" target="_blank">https://cdn.jsdelivr.net/gh/nextapps-de/flexsearch@0.8.2/dist/flexsearch.compact.module.min.js</a></td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td>flexsearch.compact.module.debug.js</td>
-        <td><a href="https://github.com/nextapps-de/flexsearch/raw/0.8.2/dist/flexsearch.compact.module.debug.js" target="_blank">Download</a></td>
-        <td><a href="https://cdn.jsdelivr.net/gh/nextapps-de/flexsearch@0.8.2/dist/flexsearch.compact.module.debug.js" target="_blank">https://cdn.jsdelivr.net/gh/nextapps-de/flexsearch@0.8.2/dist/flexsearch.compact.module.debug.js</a></td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td>flexsearch.light.min.js</td>
-        <td><a href="https://github.com/nextapps-de/flexsearch/raw/0.8.2/dist/flexsearch.light.min.js" target="_blank">Download</a></td>
-        <td><a href="https://cdn.jsdelivr.net/gh/nextapps-de/flexsearch@0.8.2/dist/flexsearch.light.min.js" target="_blank">https://cdn.jsdelivr.net/gh/nextapps-de/flexsearch@0.8.2/dist/flexsearch.light.min.js</a></td>
-    </tr>****
-    <tr></tr>
-    <tr>
-        <td>flexsearch.light.debug.js</td>
-        <td><a href="https://github.com/nextapps-de/flexsearch/raw/0.8.2/dist/flexsearch.light.debug.js" target="_blank">Download</a></td>
-        <td><a href="https://cdn.jsdelivr.net/gh/nextapps-de/flexsearch@0.8.2/dist/flexsearch.light.debug.js" target="_blank">https://cdn.jsdelivr.net/gh/nextapps-de/flexsearch@0.8.2/dist/flexsearch.light.debug.js</a></td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td>flexsearch.light.module.min.js</td>
-        <td><a href="https://github.com/nextapps-de/flexsearch/raw/0.8.2/dist/flexsearch.light.module.min.js" target="_blank">Download</a></td>
-        <td><a href="https://cdn.jsdelivr.net/gh/nextapps-de/flexsearch@0.8.2/dist/flexsearch.light.module.min.js" target="_blank">https://cdn.jsdelivr.net/gh/nextapps-de/flexsearch@0.8.2/dist/flexsearch.light.module.min.js</a></td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td>flexsearch.light.module.debug.js</td>
-        <td><a href="https://github.com/nextapps-de/flexsearch/raw/0.8.2/dist/flexsearch.light.module.debug.js" target="_blank">Download</a></td>
-        <td><a href="https://cdn.jsdelivr.net/gh/nextapps-de/flexsearch@0.8.2/dist/flexsearch.light.module.debug.js" target="_blank">https://cdn.jsdelivr.net/gh/nextapps-de/flexsearch@0.8.2/dist/flexsearch.light.module.debug.js</a></td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td>flexsearch.es5.min.js</td>
-        <td><a href="https://github.com/nextapps-de/flexsearch/raw/0.8.2/dist/flexsearch.es5.min.js" target="_blank">Download</a></td>
-        <td><a href="https://cdn.jsdelivr.net/gh/nextapps-de/flexsearch@0.8.2/dist/flexsearch.es5.min.js" target="_blank">https://cdn.jsdelivr.net/gh/nextapps-de/flexsearch@0.8.2/dist/flexsearch.es5.min.js</a></td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td>flexsearch.es5.debug.js</td>
-        <td><a href="https://github.com/nextapps-de/flexsearch/raw/0.8.2/dist/flexsearch.es5.debug.js" target="_blank">Download</a></td>
-        <td><a href="https://cdn.jsdelivr.net/gh/nextapps-de/flexsearch@0.8.2/dist/flexsearch.es5.debug.js" target="_blank">https://cdn.jsdelivr.net/gh/nextapps-de/flexsearch@0.8.2/dist/flexsearch.es5.debug.js</a></td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td>Javascript Modules (ESM)</td>
-        <td><a href="https://download-directory.github.io/?url=https%3A%2F%2Fgithub.com%2Fnextapps-de%2Fflexsearch%2Ftree%2F0.8.2%2Fdist%2Fmodule" target="_blank">Download</a></td>
-        <td><a href="https://cdn.jsdelivr.net/gh/nextapps-de/flexsearch@0.8.2/dist/module/" target="_blank">https://cdn.jsdelivr.net/gh/nextapps-de/flexsearch@0.8.2/dist/module/</a></td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td>Javascript Modules Minified (ESM)</td>
-        <td><a href="https://download-directory.github.io/?url=https%3A%2F%2Fgithub.com%2Fnextapps-de%2Fflexsearch%2Ftree%2F0.8.2%2Fdist%2Fmodule-min" target="_blank">Download</a></td>
-        <td><a href="https://cdn.jsdelivr.net/gh/nextapps-de/flexsearch@0.8.2/dist/module-min/" target="_blank">https://cdn.jsdelivr.net/gh/nextapps-de/flexsearch@0.8.2/dist/module-min/</a></td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td>Javascript Modules Debug (ESM)</td>
-        <td><a href="https://download-directory.github.io/?url=https%3A%2F%2Fgithub.com%2Fnextapps-de%2Fflexsearch%2Ftree%2F0.8.2%2Fdist%2Fmodule-debug" target="_blank">Download</a></td>
-        <td><a href="https://cdn.jsdelivr.net/gh/nextapps-de/flexsearch@0.8.2/dist/module-debug/" target="_blank">https://cdn.jsdelivr.net/gh/nextapps-de/flexsearch@0.8.2/dist/module-debug/</a></td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td>flexsearch.custom.js</td>
-        <td colspan="2"><a href="/doc/custom-builds.md">Read more about "Custom Build"</a></td>
-    </tr>
-</table>
+|                                    |          |                                                                                                  |
+|------------------------------------|----------|--------------------------------------------------------------------------------------------------|
+| Build                              | File     | CDN                                                                                              |
+| flexsearch.bundle.min.js           | Download | https://cdn.jsdelivr.net/gh/nextapps-de/flexsearch@0.8.2/dist/flexsearch.bundle.min.js           |
+| flexsearch.bundle.debug.js         | Download | https://cdn.jsdelivr.net/gh/nextapps-de/flexsearch@0.8.2/dist/flexsearch.bundle.debug.js         |
+| flexsearch.bundle.module.min.js    | Download | https://cdn.jsdelivr.net/gh/nextapps-de/flexsearch@0.8.2/dist/flexsearch.bundle.module.min.js    |
+| flexsearch.bundle.module.debug.js  | Download | https://cdn.jsdelivr.net/gh/nextapps-de/flexsearch@0.8.2/dist/flexsearch.bundle.module.debug.js  |
+| flexsearch.compact.min.js          | Download | https://cdn.jsdelivr.net/gh/nextapps-de/flexsearch@0.8.2/dist/flexsearch.compact.min.js          |
+| flexsearch.compact.debug.js        | Download | https://cdn.jsdelivr.net/gh/nextapps-de/flexsearch@0.8.2/dist/flexsearch.compact.debug.js        |
+| flexsearch.compact.module.min.js   | Download | https://cdn.jsdelivr.net/gh/nextapps-de/flexsearch@0.8.2/dist/flexsearch.compact.module.min.js   |
+| flexsearch.compact.module.debug.js | Download | https://cdn.jsdelivr.net/gh/nextapps-de/flexsearch@0.8.2/dist/flexsearch.compact.module.debug.js |
+| flexsearch.light.min.js            | Download | https://cdn.jsdelivr.net/gh/nextapps-de/flexsearch@0.8.2/dist/flexsearch.light.min.js            |
+| flexsearch.light.debug.js          | Download | https://cdn.jsdelivr.net/gh/nextapps-de/flexsearch@0.8.2/dist/flexsearch.light.debug.js          |
+| flexsearch.light.module.min.js     | Download | https://cdn.jsdelivr.net/gh/nextapps-de/flexsearch@0.8.2/dist/flexsearch.light.module.min.js     |
+| flexsearch.light.module.debug.js   | Download | https://cdn.jsdelivr.net/gh/nextapps-de/flexsearch@0.8.2/dist/flexsearch.light.module.debug.js   |
+| flexsearch.es5.min.js              | Download | https://cdn.jsdelivr.net/gh/nextapps-de/flexsearch@0.8.2/dist/flexsearch.es5.min.js              |
+| flexsearch.es5.debug.js            | Download | https://cdn.jsdelivr.net/gh/nextapps-de/flexsearch@0.8.2/dist/flexsearch.es5.debug.js            |
+| Javascript Modules (ESM)           | Download | https://cdn.jsdelivr.net/gh/nextapps-de/flexsearch@0.8.2/dist/module/                            |
+| Javascript Modules Minified (ESM)  | Download | https://cdn.jsdelivr.net/gh/nextapps-de/flexsearch@0.8.2/dist/module-min/                        |
+| Javascript Modules Debug (ESM)     | Download | https://cdn.jsdelivr.net/gh/nextapps-de/flexsearch@0.8.2/dist/module-debug/                      |
+| flexsearch.custom.js | Read more about "Custom Build" |
+
 
 </details>
 <a name="bundles"></a>
@@ -427,154 +232,27 @@ The **_dist_** folder is located in: `node_modules/flexsearch/dist/`
 
 > The Node.js package includes all features.
 
-<table>
-    <tr></tr>
-    <tr>
-        <td>Feature</td>
-        <td>flexsearch.bundle.js</td>
-        <td>flexsearch.compact.js</td>
-        <td>flexsearch.light.js</td>
-    </tr>
-    <tr>
-        <td>
-            <a href="#presets">Presets</a>
-        </td>
-        <td>✓</td>
-        <td>✓</td>
-        <td>✓</td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td>
-            <a href="doc/async.md">Async Processing</a>
-        </td>
-        <td>✓</td>
-        <td>✓</td>
-        <td>-</td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td>
-            <a href="doc/worker.md">Workers (Web + Node.js)</a>
-        </td>
-        <td>✓</td>
-        <td>-</td>
-        <td>-</td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td>
-            <a href="#context-search">Context Search</a>
-        </td>
-        <td>✓</td>
-        <td>✓</td>
-        <td>✓</td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td>
-            <a href="doc/document-search.md">Document Search</a>
-        </td>
-        <td>✓</td>
-        <td>✓</td>
-        <td>-</td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td>
-            <a href="doc/document-search.md#store">Document Datastore</a>
-        </td>
-        <td>✓</td>
-        <td>✓</td>
-        <td>-</td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td>
-            <a href="#tokenizer">Partial Matching</a>
-        </td>
-        <td>✓</td>
-        <td>✓</td>
-        <td>✓</td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td>
-            <a href="doc/cache.md">Auto-Balanced Cache by Popularity/Last Queries</a>
-        </td>
-        <td>✓</td>
-        <td>✓</td>
-        <td>-</td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td>
-            <a href="doc/document-search.md#tag-search">Tag Search</a>
-        </td>
-        <td>✓</td>
-        <td>✓</td>
-        <td>-</td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td>
-            <a href="#suggestions">Suggestions</a>
-        </td>
-        <td>✓</td>
-        <td>✓</td>
-        <td>✓</td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td>
-            <a href="#fuzzy-search">Phonetic Search (Fuzzy Search)</a>
-        </td>
-        <td>✓</td>
-        <td>✓</td>
-        <td>-</td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td><a href="doc/encoder.md">Encoder</a></td>
-        <td>✓</td>
-        <td>✓</td>
-        <td>✓</td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td><a href="doc/export-import.md">Export / Import Indexes</a></td>
-        <td>✓</td>
-        <td>✓</td>
-        <td>-</td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td><a href="doc/resolver.md">Resolver</a></td>
-        <td>✓</td>
-        <td>-</td>
-        <td>-</td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td><a href="doc/result-highlighting.md">Result Highlighting</a></td>
-        <td>✓</td>
-        <td>✓</td>
-        <td>-</td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td><a href="doc/persistent.md">Persistent Index (IndexedDB)</a></td>
-        <td>✓</td>
-        <td>-</td>
-        <td>-</td>
-    </tr>
-    <tr>
-        <td>File Size (gzip)</td>
-        <td>16.3 kb</td>
-        <td>11.4 kb</td>
-        <td>4.5 kb</td>
-    </tr>
-</table>
+|                                                |                      |                       |                     |
+|------------------------------------------------|----------------------|-----------------------|---------------------|
+| Feature                                        | flexsearch.bundle.js | flexsearch.compact.js | flexsearch.light.js |
+| Presets                                        | ✓                    | ✓                     | ✓                   |
+| Async Processing                               | ✓                    | ✓                     | -                   |
+| Workers (Web + Node.js)                        | ✓                    | -                     | -                   |
+| Context Search                                 | ✓                    | ✓                     | ✓                   |
+| Document Search                                | ✓                    | ✓                     | -                   |
+| Document Datastore                             | ✓                    | ✓                     | -                   |
+| Partial Matching                               | ✓                    | ✓                     | ✓                   |
+| Auto-Balanced Cache by Popularity/Last Queries | ✓                    | ✓                     | -                   |
+| Tag Search                                     | ✓                    | ✓                     | -                   |
+| Suggestions                                    | ✓                    | ✓                     | ✓                   |
+| Phonetic Search (Fuzzy Search)                 | ✓                    | ✓                     | -                   |
+| Encoder                                        | ✓                    | ✓                     | ✓                   |
+| Export / Import Indexes                        | ✓                    | ✓                     | -                   |
+| Resolver                                       | ✓                    | -                     | -                   |
+| Result Highlighting                            | ✓                    | ✓                     | -                   |
+| Persistent Index (IndexedDB)                   | ✓                    | -                     | -                   |
+| File Size (gzip)                               | 16.3 kb              | 11.4 kb               | 4.5 kb              |
+
 
 </details>
 
@@ -657,7 +335,7 @@ Or import FlexSearch members separately by:
 
 ```html
 <script type="module">
-    import { Index, Document, Encoder, Charset, Resolver, Worker, IndexedDB } 
+    import { Index, Document, Encoder, Charset, Resolver, Worker, IndexedDB }
         from "./dist/flexsearch.bundle.module.min.js";
     const index = new Index(/* ... */);
 </script>
@@ -864,7 +542,7 @@ The documentation will refer to several examples. A list of all examples:
 - [document-worker](example/browser-module/document-worker)
 - [document-worker-extern-config](example/browser-module/document-worker-extern-config)
 - [language-pack](example/browser-module/language-pack)
-  
+
 </details>
 
 ## API Overview
@@ -1069,7 +747,7 @@ const index = new Index({
 });
 ```
 
-Related Topics: [Index Options](#index-options) 
+Related Topics: [Index Options](#index-options)
 &ensp;&bull;&ensp; [Resolution](#resolution)
 &ensp;&bull;&ensp; [Charset Collection](#charset-collection)
 &ensp;&bull;&ensp; [Tokenizer](#tokenizer-partial-match)
@@ -1146,211 +824,37 @@ index.remove(0).update(1, 'foo').add(2, 'foobar');
 
 ## Index Options
 
-<table>
-    <tr></tr>
-    <tr>
-        <td>Option</td>
-        <td>Values</td>
-        <td>Description</td>
-        <td>Default</td>
-    </tr>
-    <tr>
-        <td>preset</td>
-        <td>
-            "memory"<br>
-            "performance"<br>
-            "match"<br>
-            "score"<br>
-            "default"
-        </td>
-        <td>
-            The <a href="#presets">configuration profile</a> as a shortcut or as a base for your custom settings.<br>
-        </td>
-        <td>"default"</td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td>tokenize</td>
-        <td>
-            "strict" / "exact"<br>
-            "tolerant"<br>
-            "forward"<br>
-            "reverse" / "bidirectional<br>
-            "full"
-        </td>
-        <td>
-            Indicates how terms should be indexed by <a href="#tokenizer-partial-match">tokenization</a>.
-        </td>
-        <td>"strict"</td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td>resolution</td>
-        <td>
-            Number
-        </td>
-        <td>Sets the scoring <a href="#resolution">resolution</a></td>
-        <td>9</td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td>encoder</td>
-        <td>
-            <a href="doc/encoder.md">new Encoder(options)</a><br>
-            Charset.Exact<br>
-            Charset.Default<br>
-            Charset.Normalize<br>
-            Charset.LatinBalance<br>
-            Charset.LatinAdvanced<br>
-            Charset.LatinExtra<br>
-            Charset.LatinSoundex<br>
-            Charset.CJK<br>
-            false
-        </td>
-        <td>Choose one of the <a href="#charset-collection">built-in encoder</a><br>Read more about <a href="doc/encoder.md">Encoder</a></td>
-        <td>"default"</td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td>encode</td>
-        <td>
-            function(string) => string[]
-        </td>
-        <td>Pass a <a href="doc/encoder.md#custom-encoder">custom encoding function</a><br>Read more about <a href="doc/encoder.md">Encoder</a></td>
-        <td>"default"</td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td>context</td>
-        <td>
-            Boolean<br>
-            <a href="#context-options">Context Options</a>
-        </td>
-        <td>Enable/Disable <a href="#context-search">context index</a>. When passing "true" as a value will use the defaults for the context.</td>
-        <td>false</td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td>cache</td>
-        <td>
-            Boolean<br>
-            Number
-        </td>
-        <td>Enable/Disable and/or set capacity of cached entries.<br><br>The cache automatically balance stored entries related to their popularity.</td>
-        <td>false</td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td>fastupdate</td>
-        <td>
-            Boolean
-        </td>
-        <td>Additionally add a <a href="#fastupdate">fastupdate index</a> which boost any replace/update/remove task to a high performance level by also increasing index size by ~30%.</td>
-        <td>false</td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td>priority</td>
-        <td>
-            Number
-        </td>
-        <td>Sets the task execution priority (1 low priority - 9 high priority) when using the <a href="doc/async.md">async methods</a></td>
-        <td>4</td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td>score</td>
-        <td>
-            function(string) => number
-        </td>
-        <td>Use a <a href="doc/customization.md">custom score function</a></td>
-        <td></td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td>keystore</td>
-        <td>
-            Number
-        </td>
-        <td>Increase available size for In-Memory-Index by additionally using uniform balanced registers (<a href="doc/keystore.md">Keystore</a>). You can apply values from 1 to 64.</td>
-        <td>false</td>
-    </tr>
-    <tr>
-        <td colspan="4">
-            Persistent Options:
-        </td>
-    </tr>
-    <tr>
-        <td>db</td>
-        <td>
-            StorageInterface
-        </td>
-        <td>Pass an instance of a <a href="doc/persistent.md">persistent adapter</a></td>
-        <td></td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td>commit</td>
-        <td>
-            Boolean
-        </td>
-        <td>When disabled any changes won't commit, instead it needs calling <code>index.commit()</code> manually to make modifications to the index (add, update, remove) persistent.</td>
-        <td>true</td>
-    </tr>
-</table>
+|        |        |             |         |
+|--------|--------|-------------|---------|
+| Option | Values | Description | Default |
+| preset | "memory", "performance", "match", "score", "default" | The configuration profile as a shortcut or as a base for your custom settings. | "default" |
+| tokenize | "strict" / "exact", "tolerant", "forward", "reverse" / "bidirectional, "full" | Indicates how terms should be indexed by tokenization. | "strict" |
+| resolution | Number | Sets the scoring resolution | 9 |
+| encoder | new Encoder(options), Charset.Exact, Charset.Default, Charset.Normalize, Charset.LatinBalance, Charset.LatinAdvanced, Charset.LatinExtra, Charset.LatinSoundex, Charset.CJK, false | Choose one of the built-in encoderRead more about Encoder | "default" |
+| encode | function(string) => string[] | Pass a custom encoding functionRead more about Encoder | "default" |
+| context | Boolean | Context Options | Enable/Disable context index. When passing "true" as a value will use the defaults for the context. | false |
+| cache | Boolean, Number | Enable/Disable and/or set capacity of cached entries.The cache automatically balance stored entries related to their popularity. | false |
+| fastupdate | Boolean | Additionally add a fastupdate index which boost any replace/update/remove task to a high performance level by also increasing index size by ~30%. | false |
+| priority | Number | Sets the task execution priority (1 low priority - 9 high priority) when using the async methods | 4 |
+| score | function(string) => number | Use a custom score function |  |
+| keystore | Number | Increase available size for In-Memory-Index by additionally using uniform balanced registers (Keystore). You can apply values from 1 to 64. | false |
+| Persistent Options: |
+| db | StorageInterface | Pass an instance of a persistent adapter |  |
+| commit | Boolean | When disabled any changes won't commit, instead it needs calling index.commit() manually to make modifications to the index (add, update, remove) persistent. | true |
+
 
 ## Search Options
 
-<table>
-    <tr></tr>
-    <tr>
-        <td>Option</td>
-        <td>Values</td>
-        <td>Description</td>
-        <td>Default</td>
-    </tr>
-    <tr>
-        <td>limit</td>
-        <td>number</td>
-        <td>Sets the limit of results</td>
-        <td>100</td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td>offset</td>
-        <td>number</td>
-        <td>Apply offset (skip items)</td>
-        <td>0</td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td>resolution</td>
-        <td>number</td>
-        <td>Limit the resolution (score) of the results</td>
-        <td></td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td>suggest</td>
-        <td>Boolean</td>
-        <td>Enables <a href="#suggestions">Suggestions</a> in results</td>
-        <td>false</td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td>cache</td>
-        <td>Boolean</td>
-        <td>Use a <a href="#auto-balanced-cache-by-popularity">Query Cache</a></td>
-        <td>false</td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td>resolve</td>
-        <td>Boolean</td>
-        <td>When set to <code>false</code>, an instance of a <a href="doc/resolver.md">Resolver</a> is returned to apply further operations</td>
-        <td>true</td>
-    </tr>
-</table>
+|            |         |                                                                                      |         |
+|------------|---------|--------------------------------------------------------------------------------------|---------|
+| Option     | Values  | Description                                                                          | Default |
+| limit      | number  | Sets the limit of results                                                            | 100     |
+| offset     | number  | Apply offset (skip items)                                                            | 0       |
+| resolution | number  | Limit the resolution (score) of the results                                          |         |
+| suggest    | Boolean | Enables Suggestions in results                                                       | false   |
+| cache      | Boolean | Use a Query Cache                                                                    | false   |
+| resolve    | Boolean | When set to false, an instance of a Resolver is returned to apply further operations | true    |
+
 
 ## Suggestions
 
@@ -1408,49 +912,15 @@ The tokenizer is one of the most important options and heavily influence:
 
 Try to choose the most upper of these tokenizer which covers your requirements:
 
-<table>
-    <tr></tr>
-    <tr>
-        <td>Option</td>
-        <td>Description</td>
-        <td>Example</td>
-        <td>Memory Factor (n = length of term)</td>
-    </tr>
-    <tr>
-        <td><code>"strict"</code><br><code>"exact"</code><br><code>"default"</code></td>
-        <td>index the full term</td>
-        <td><code>foobar</code></td>
-        <td>1</td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td><code>"forward"</code></td>
-        <td>index term in forward direction (supports right-to-left by Index option <code>rtl: true</code>)</td>
-        <td><code>fo</code>obar<br><code>foob</code>ar<br></td>
-        <td>n</td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td><code>"reverse"</code><br><code>"bidirectional"</code></td>
-        <td>index term in both directions</td>
-        <td><code>fo</code>obar<br><code>foob</code>ar<br>foob<code>ar</code><br>fo<code>obar</code></td>
-        <td>2n - 1</td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td><code>"tolerant"</code></td>
-        <td>index the full term by also being tolerant against typos like swapped letters and missing letters</td>
-        <td><code>foobra</code><br><code>foboar</code><br><code>foobr</code><br><code>fooba</code></td>
-        <td>2(n - 2) + 2</td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td><code>"full"</code></td>
-        <td>index every consecutive partial</td>
-        <td>fo<code>oba</code>r<br>f<code>oob</code>ar</td>
-        <td>n * (n - 1)</td>
-    </tr>
-</table>
+|                          |                                                                                                   |                          |                                    |
+|--------------------------|---------------------------------------------------------------------------------------------------|--------------------------|------------------------------------|
+| Option                   | Description                                                                                       | Example                  | Memory Factor (n = length of term) |
+| "strict""exact""default" | index the full term                                                                               | foobar                   | 1                                  |
+| "forward"                | index term in forward direction (supports right-to-left by Index option rtl: true)                | foobarfoobar             | n                                  |
+| "reverse""bidirectional" | index term in both directions                                                                     | foobarfoobarfoobarfoobar | 2n - 1                             |
+| "tolerant"               | index the full term by also being tolerant against typos like swapped letters and missing letters | foobrafoboarfoobrfooba   | 2(n - 2) + 2                       |
+| "full"                   | index every consecutive partial                                                                   | foobarfoobar             | n * (n - 1)                        |
+
 
 ## Charset Collection
 
@@ -1459,62 +929,17 @@ Encoding is one of the most important task and heavily influence:
 1. required memory / storage
 2. capabilities of phonetic matches (Fuzzy-Search)
 
-<table>
-    <tr></tr>
-    <tr>
-        <td>Option</td>
-        <td>Description</td>
-        <td>Charset Type</td>
-        <td>Compression Ratio</td>
-    </tr>
-    <tr>
-        <td><code>Exact</code></td>
-        <td>Bypass encoding and take exact input</td>
-        <td>Universal (multi-lang)</td>
-        <td>0%</td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td><code>Normalize</code><br><code>Default</code></td>
-        <td>Case in-sensitive encoding<br>Charset normalization<br>Letter deduplication</td>
-        <td>Universal (multi-lang)</td>
-        <td>~ 7%</td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td><code>LatinBalance</code></td>
-        <td>Case in-sensitive encoding<br>Charset normalization<br>Letter deduplication<br>Phonetic basic transformation</td>
-        <td>Latin</td>
-        <td>~ 30%</td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td><code>LatinAdvanced</code></td>
-        <td>Case in-sensitive encoding<br>Charset normalization<br>Letter deduplication<br>Phonetic advanced transformation</td>
-        <td>Latin</td>
-        <td>~ 45%</td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td><code>LatinExtra</code></td>
-        <td>Case in-sensitive encoding<br>Charset normalization<br>Letter deduplication<br>Soundex-like transformation</td>
-        <td>Latin</td>
-        <td>~ 60%</td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td><code>LatinSoundex</code></td>
-        <td>Full Soundex transformation</td>
-        <td>Latin</td>
-        <td>~ 70%</td>
-    </tr>
-    <tr>
-        <td><code>function(str) => [str]</code></td>
-        <td>Pass a custom encoding function to the <code>Encoder</code></td>
-        <td></td>
-        <td></td>
-    </tr>
-</table>
+|                        |                                                                                                     |                        |                   |
+|------------------------|-----------------------------------------------------------------------------------------------------|------------------------|-------------------|
+| Option                 | Description                                                                                         | Charset Type           | Compression Ratio |
+| Exact                  | Bypass encoding and take exact input                                                                | Universal (multi-lang) | 0%                |
+| NormalizeDefault       | Case in-sensitive encodingCharset normalizationLetter deduplication                                 | Universal (multi-lang) | ~ 7%              |
+| LatinBalance           | Case in-sensitive encodingCharset normalizationLetter deduplicationPhonetic basic transformation    | Latin                  | ~ 30%             |
+| LatinAdvanced          | Case in-sensitive encodingCharset normalizationLetter deduplicationPhonetic advanced transformation | Latin                  | ~ 45%             |
+| LatinExtra             | Case in-sensitive encodingCharset normalizationLetter deduplicationSoundex-like transformation      | Latin                  | ~ 60%             |
+| LatinSoundex           | Full Soundex transformation                                                                         | Latin                  | ~ 70%             |
+| function(str) => [str] | Pass a custom encoding function to the Encoder                                                      |                        |                   |
+
 
 ## Fuzzy-Search
 
@@ -1531,80 +956,16 @@ Additionally, you can apply custom `Mapper`, `Replacer`, `Stemmer`, `Filter` or 
 
 Original term which was indexed: "Struldbrugs"
 
-<table>
-    <tr>
-        <th align="left">Encoder:</th>
-        <th><code>Exact</code></th>
-        <th><code>Normalize (Default)</code></th>
-        <th><code>LatinBalance</code></th>
-        <th><code>LatinAdvanced</code></th>
-        <th><code>LatinExtra</code></th>
-        <th><code>LatinSoundex</code></th>
-    </tr>
-    <tr>
-        <th align="left">Index Size</th>
-        <th>3.1 Mb</th>
-        <th>1.9 Mb</th>
-        <th>1.7 Mb</th>
-        <th>1.6 Mb</th>
-        <th>1.1 Mb</th>
-        <th>0.7 Mb</th>
-    </tr>
-    <tr>
-        <td align="left">Struldbrugs</td>
-        <td>✓</td>
-        <td>✓</td>
-        <td>✓</td>
-        <td>✓</td>
-        <td>✓</td>
-        <td>✓</td>
-    </tr>
-    <tr>
-        <td align="left">strũlldbrųĝgs</td>
-        <td></td>
-        <td>✓</td>
-        <td>✓</td>
-        <td>✓</td>
-        <td>✓</td>
-        <td>✓</td>
-    </tr>
-    <tr>
-        <td align="left">strultbrooks</td>
-        <td></td>
-        <td></td>
-        <td>✓</td>
-        <td>✓</td>
-        <td>✓</td>
-        <td>✓</td>
-    </tr>
-    <tr>
-        <td align="left">shtruhldbrohkz</td>
-        <td></td>
-        <td></td>
-        <td></td>
-        <td>✓</td>
-        <td>✓</td>
-        <td>✓</td>
-    </tr>
-    <tr>
-        <td align="left">zdroltbrykz</td>
-        <td></td>
-        <td></td>
-        <td></td>
-        <td></td>
-        <td>✓</td>
-        <td>✓</td>
-    </tr>
-    <tr>
-        <td align="left">struhlbrogger</td>
-        <td></td>
-        <td></td>
-        <td></td>
-        <td></td>
-        <td></td>
-        <td>✓</td>
-    </tr>
-</table>
+| Encoder:       | Exact  | Normalize (Default) | LatinBalance | LatinAdvanced | LatinExtra | LatinSoundex |
+|----------------|--------|---------------------|--------------|---------------|------------|--------------|
+| **Index Size**     | **3.1 Mb** | **1.9 Mb**            | **1.7 Mb**       | **1.6 Mb**        | **1.1 Mb**    | **0.7 Mb**       |
+| Struldbrugs    | ✓      | ✓                   | ✓            | ✓             | ✓          | ✓            |
+| strũlldbrųĝgs  |        | ✓                   | ✓            | ✓             | ✓          | ✓            |
+| strultbrooks   |        |                     | ✓            | ✓             | ✓          | ✓            |
+| shtruhldbrohkz |        |                     |              | ✓             | ✓          | ✓            |
+| zdroltbrykz    |        |                     |              |               | ✓          | ✓            |
+| struhlbrogger  |        |                     |              |               |            | ✓            |
+
 
 The index size was measured after indexing the book "Gulliver's Travels".
 
@@ -1658,7 +1019,7 @@ Create an index and apply custom options for the context:
 ```js
 var index = new FlexSearch({
     tokenize: "strict",
-    context: { 
+    context: {
         resolution: 5,
         depth: 3,
         bidirectional: true
@@ -1696,42 +1057,13 @@ The first index returns ID 1 in the first slot for the best pick, because matche
 
 ### Context Options
 
-<table>
-    <tr></tr>
-    <tr>
-        <td>Option</td>
-        <td>Values</td>
-        <td>Description</td>
-        <td>Default</td>
-    </tr>
-    <tr>
-        <td>resolution</td>
-        <td>
-            Number
-        </td>
-        <td>Sets the scoring <a href="#resolution">resolution</a> for the context.</td>
-        <td>3</td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td>depth<br><br></td>
-        <td>
-            false<br>
-            Number
-        </td>
-        <td>Enable/Disable context index and also sets the maximum initial distance of related terms.</td>
-        <td>1</td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td>bidirectional</td>
-        <td>
-            Boolean
-        </td>
-        <td>If enabled the context direction (aka "context chain") can move bidirectional. You should ony disable this options when you need a more exact match with fewer results.</td>
-        <td>true</td>
-    </tr>
-</table>
+|            |        |                                              |         |
+|------------|--------|----------------------------------------------|---------|
+| Option     | Values | Description                                  | Default |
+| resolution | Number | Sets the scoring resolution for the context. | 3       |
+| depth | false | Number | Enable/Disable context index and also sets the maximum initial distance of related terms. | 1 |
+| bidirectional | Boolean | If enabled the context direction (aka "context chain") can move bidirectional. You should ony disable this options when you need a more exact match with fewer results. | true |
+
 
 ## Auto-Balanced Cache (By Popularity)
 

--- a/doc/custom-builds.md
+++ b/doc/custom-builds.md
@@ -33,13 +33,13 @@ npm run build:custom SUPPORT_DOCUMENT=true SUPPORT_TAGS=true LANGUAGE_OUT=ECMASC
 Perform a custom build in ESM module format:
 
 ```bash
-npm run build:custom RELEASE=custom.module SUPPORT_DOCUMENT=true SUPPORT_TAGS=true 
+npm run build:custom RELEASE=custom.module SUPPORT_DOCUMENT=true SUPPORT_TAGS=true
 ```
 
 Perform a debug build:
 
 ```bash
-npm run build:custom DEBUG=true SUPPORT_DOCUMENT=true SUPPORT_TAGS=true 
+npm run build:custom DEBUG=true SUPPORT_DOCUMENT=true SUPPORT_TAGS=true
 ```
 
 > On custom builds each build flag will be set to `false` by default when not passed.
@@ -54,136 +54,29 @@ The custom build will be saved to `dist/flexsearch.custom.xxxx.min.js` or when f
 
 ### Supported Build Flags
 
-<table>
-    <tr>
-        <td>Flag</td>
-        <td>Values</td>
-        <td>Info</td>
-    </tr>
-    <tr>
-        <td colspan="3"><br><b>Feature Flags</b></td>
-    </tr>
-    <tr>
-        <td>SUPPORT_WORKER</td>
-        <td>true, false</td>
-        <td>Worker Indexes</td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td>SUPPORT_ENCODER</td>
-        <td>true, false</td>
-        <td>When not included you'll need to pass a custom <code>encode</code> method when creating an index</td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td>SUPPORT_CHARSET</td>
-        <td>true, false</td>
-        <td>Includes: <code>LatinBalance</code>, <code>LatinAdvanced</code>, <code>LatinExtra</code>, <code>LatinSoundex</code></td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td>SUPPORT_CACHE</td>
-        <td>true, false</td>
-        <td>Support for <code>index.searchCache()</code></td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td>SUPPORT_ASYNC</td>
-        <td>true, false</td>
-        <td>The async version of index standard methods</td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td>SUPPORT_STORE</td>
-        <td>true, false</td>
-        <td>Document Datastore</td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td>SUPPORT_SUGGESTION</td>
-        <td>true, false</td>
-        <td>Use the option <code>suggestions</code> when searching</td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td>SUPPORT_SERIALIZE</td>
-        <td>true, <b>false</b></td>
-        <td>Export / Import / Serialize Index</td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td>SUPPORT_DOCUMENT</td>
-        <td>true, false</td>
-        <td>Document Indexes</td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td>SUPPORT_TAGS</td>
-        <td>true, false</td>
-        <td>Tag-Search</td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td>SUPPORT_PERSISTENT</td>
-        <td>true, false</td>
-        <td>Use any of the persistent indexes</td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td>SUPPORT_KEYSTORE</td>
-        <td>true, false</td>
-        <td>Extended size for InMemory indexes</td>
-    </tr>
-    <!--
-    <tr></tr>
-    <tr>
-        <td>SUPPORT_COMPRESSION</td>
-        <td>true, false</td>
-        <td></td>
-    </tr>
-    -->
-    <tr></tr>
-    <tr>
-        <td>SUPPORT_RESOLVER</td>
-        <td>true, false</td>
-        <td>Apply complex queries by chaining boolean operations</td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td>SUPPORT_HIGHLIGHTING</td>
-        <td>true, false</td>
-        <td>Result Highlighting for Document-Search (also requires <code>SUPPORT_STORE</code>)</td>
-    </tr>
-    <tr>
-        <td colspan="3"><br><b>Compiler Flags</b></td>
-    </tr>
-    <tr>
-        <td>DEBUG</td>
-        <td>true, false</td>
-        <td>Apply common checks and throw errors more frequently, output debug information and helpful hints to the console</td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td>RELEASE</td>
-        <td>custom<br>custom.module</td>
-        <td>Choose build schema: custom = Legacy Browser (<code>window.FlexSearch</code>), custom.module = ES6 Modules (ESM)</td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td>POLYFILL</td>
-        <td>true, false</td>
-        <td>Include Polyfills (based on <code>LANGUAGE_OUT</code>)</td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td>PROFILER</td>
-        <td>true, false</td>
-        <td>Just used for automatic performance tests</td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td>LANGUAGE_OUT</td>
-        <td>ECMASCRIPT3<br>ECMASCRIPT5<br>ECMASCRIPT_2015<br>ECMASCRIPT_2016<br>ECMASCRIPT_2017<br>ECMASCRIPT_2018<br>ECMASCRIPT_2019<br>ECMASCRIPT_2020<br>ECMASCRIPT_2021<br>ECMASCRIPT_2022<br>ECMASCRIPT_NEXT<br>STABLE</td>
-        <td>Target language</td>
-    </tr>
-</table>
+|      |        |      |
+|------|--------|------|
+| Flag | Values | Info |
+| Feature Flags |
+| SUPPORT_WORKER | true, false | Worker Indexes |
+| SUPPORT_ENCODER | true, false | When not included you'll need to pass a custom encode method when creating an index |
+| SUPPORT_CHARSET | true, false | Includes: LatinBalance, LatinAdvanced, LatinExtra, LatinSoundex |
+| SUPPORT_CACHE | true, false | Support for index.searchCache() |
+| SUPPORT_ASYNC | true, false | The async version of index standard methods |
+| SUPPORT_STORE | true, false | Document Datastore |
+| SUPPORT_SUGGESTION | true, false | Use the option suggestions when searching |
+| SUPPORT_SERIALIZE | true, false | Export / Import / Serialize Index |
+| SUPPORT_DOCUMENT | true, false | Document Indexes |
+| SUPPORT_TAGS | true, false | Tag-Search |
+| SUPPORT_PERSISTENT | true, false | Use any of the persistent indexes |
+| SUPPORT_KEYSTORE | true, false | Extended size for InMemory indexes |
+| SUPPORT_COMPRESSION | true, false |  |
+| SUPPORT_RESOLVER | true, false | Apply complex queries by chaining boolean operations |
+| SUPPORT_HIGHLIGHTING | true, false | Result Highlighting for Document-Search (also requires SUPPORT_STORE) |
+| Compiler Flags |
+| DEBUG | true, false | Apply common checks and throw errors more frequently, output debug information and helpful hints to the console |
+| RELEASE | customcustom.module | Choose build schema: custom = Legacy Browser (window.FlexSearch), custom.module = ES6 Modules (ESM) |
+| POLYFILL | true, false | Include Polyfills (based on LANGUAGE_OUT) |
+| PROFILER | true, false | Just used for automatic performance tests |
+| LANGUAGE_OUT | ECMASCRIPT3ECMASCRIPT5ECMASCRIPT_2015ECMASCRIPT_2016ECMASCRIPT_2017ECMASCRIPT_2018ECMASCRIPT_2019ECMASCRIPT_2020ECMASCRIPT_2021ECMASCRIPT_2022ECMASCRIPT_NEXTSTABLE | Target language |
+

--- a/doc/document-search.md
+++ b/doc/document-search.md
@@ -18,167 +18,58 @@ FlexSearch Documents also contain these features:
 
 > Document options basically inherits from [Index Options](../README.md#index-options), so you can apply most of those options either in the top scope of the config (for all fields) or as per field or both of them.
 
-<table>
-    <tr></tr>
-    <tr>
-        <td>Option</td>
-        <td>Values</td>
-        <td>Description</td>
-        <td>Default</td>
-    </tr>
-    <tr>
-        <td><code>document</code></td>
-        <td><a href="#the-document-descriptor">Document Descriptor</a></td>
-        <td>Includes any specific information about how the document data should be indexed</td>
-        <td style="font-style: italic">(mandatory)</td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td><code>worker</code></td>
-        <td>Boolean<br>String</td>
-        <td>Enable a worker distributed model. Read more about here: <a href="worker.md">Worker Index</a></td>
-        <td><code>false</code></td>
-    </tr>
-</table>
+| Option   | Values              | Description                                                                     | Default     |
+|----------|---------------------|---------------------------------------------------------------------------------|-------------|
+| document | Document Descriptor | Includes any specific information about how the document data should be indexed | (mandatory) |
+| worker   | BooleanString       | Enable a worker distributed model. Read more about here: Worker Index           | false       |
+
 
 ### Document Search Options
 
 > Document search options basically inherit from [Index Search Options](../README.md#search-options), so you can apply most of those options either in the top scope of the config (for all fields) or as per field or both of them.
 
-<table>
-    <tr></tr>
-    <tr>
-        <td>Option</td>
-        <td>Values</td>
-        <td>Description</td>
-        <td>Default</td>
-    </tr>
-    <tr>
-        <td><code>index</code><br><code>field</code></td>
-        <td>String<br>Array&lt;String&gt;<br>Array&lt;SearchOptions&gt;</td>
-        <td>Sets the <a href="#docs">document fields</a> which should be searched. When no field is set, all fields will be searched. <a href="#options-field-search">Custom options per field</a> are also supported.</td>
-        <td></td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td><code>tag</code></td>
-        <td>Object&lt;field:tag&gt;</td>
-        <td>Sets the <a href="#docs">document fields</a> which should be searched. When no field is set, all fields will be searched. <a href="#options-field-search">Custom options per field</a> are also supported.</td>
-        <td></td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td><code>enrich</code></td>
-        <td>Boolean</td>
-        <td>Enrich IDs from the results with the corresponding documents.</td>
-        <td><code>false</code></td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td><code>highlight</code></td>
-        <td>
-            <a href="./result-highlighting.md#highlighting-options">Highlighting Options</a><br>
-            String
-        </td>
-        <td>Highlight query matches in the result (for Document Indexes only)</td>
-        <td><code>false</code></td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td><code>merge</code></td>
-        <td>Boolean</td>
-        <td>Merge multiple fields in resultset into one and group results per ID</td>
-        <td><code>false</code></td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td><code>pluck</code></td>
-        <td>String</td>
-        <td>Pick and apply search to just one field and return a flat result representation</td>
-        <td><code>false</code></td>
-    </tr>
-</table>
+|            |                                                     |                                                                                                                                                    |         |
+|------------|-----------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------|---------|
+| Option     | Values                                              | Description                                                                                                                                        | Default |
+| indexfield | StringArray&lt;String&gt;Array&lt;SearchOptions&gt; | Sets the document fields which should be searched. When no field is set, all fields will be searched. Custom options per field are also supported. |         |
+| tag        | Object&lt;field:tag&gt;                             | Sets the document fields which should be searched. When no field is set, all fields will be searched. Custom options per field are also supported. |         |
+| enrich     | Boolean                                             | Enrich IDs from the results with the corresponding documents.                                                                                      | false   |
+| highlight | Highlighting Options
+            String | Highlight query matches in the result (for Document Indexes only) | false |
+| merge | Boolean | Merge multiple fields in resultset into one and group results per ID | false |
+| pluck | String | Pick and apply search to just one field and return a flat result representation | false |
+
 
 ## The Document Descriptor
 
 When creating a `Document`-Index you will need to define a document descriptor in the field `document`. This descriptor is including any specific information about how the document data should be indexed.
 
-<table>
-    <tr></tr>
-    <tr>
-        <td>Option</td>
-        <td>Values</td>
-        <td>Description</td>
-        <td>Default</td>
-    </tr>
-    <tr>
-        <td><code>id</code></td>
-        <td>String</td>
-        <td></td>
-        <td><code>"id"</code></td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td><code>index</code></td>
-        <td>String<br>Array&lt;String><br>Array&lt;FieldOptions></td>
-        <td></td>
-        <td></td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td><code>tag</code></td>
-        <td>String<br>Array&lt;String><br>Array&lt;FieldOptions></td>
-        <td></td>
-        <td></td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td><code>store</code></td>
-        <td>Boolean<br>String<br>Array&lt;String><br>Array&lt;FieldOptions></td>
-        <td></td>
-        <td><code>false</code></td>
-    </tr>
-</table>
+|        |                                                     |             |         |
+|--------|-----------------------------------------------------|-------------|---------|
+| Option | Values                                              | Description | Default |
+| id     | String                                              |             | "id"    |
+| index  | StringArray&lt;String>Array&lt;FieldOptions>        |             |         |
+| tag    | StringArray&lt;String>Array&lt;FieldOptions>        |             |         |
+| store  | BooleanStringArray&lt;String>Array&lt;FieldOptions> |             | false   |
+
 
 ### Field Options
 
 > You can use all standard [Index Options](../README.md#index-options) within field options.
 
-<table>
-    <tr></tr>
-    <tr>
-        <td>Option</td>
-        <td>Values</td>
-        <td>Description</td>
-        <td>Default</td>
-    </tr>
-    <tr>
-        <td><code>field</code></td>
-        <td>String</td>
-        <td>The field name (colon seperated syntax)</td>
-        <td style="font-style: italic">(mandatory)</td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td><code>filter</code></td>
-        <td>Function</td>
-        <td></td>
-        <td></td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td><code>custom</code></td>
-        <td>Function</td>
-        <td></td>
-        <td></td>
-    </tr>
-</table>
+|        |          |                                         |             |
+|--------|----------|-----------------------------------------|-------------|
+| Option | Values   | Description                             | Default     |
+| field  | String   | The field name (colon seperated syntax) | (mandatory) |
+| filter | Function |                                         |             |
+| custom | Function |                                         |             |
+
 
 Assuming our document has a simple data structure like this:
 
 ```json
-{ 
-    "id": 0, 
+{
+    "id": 0,
     "content": "some text"
 }
 ```
@@ -198,8 +89,8 @@ const index = new Document({
 });
 
 // add documents to the index
-index.add({ 
-    id: 0, 
+index.add({
+    id: 0,
     content: "some text"
 });
 ```
@@ -432,7 +323,7 @@ const index = new Document({
 Remember when searching you have to use the same colon-separated-string as a key from your field definition.
 
 ```js
-index.search(query, { 
+index.search(query, {
     index: "contents:body:title"
 });
 ```
@@ -499,7 +390,7 @@ function add(sequential_data){
             // add to index
             index.add(record);
         }
-    }  
+    }
 }
 
 // now just use add() helper method as usual:
@@ -674,7 +565,7 @@ By passing the search option `merge: true` all fields of the result set will be 
 When using `pluck` instead of `field` you can explicitly select just one field and get back a flat representation:
 
 ```js
-index.search(query, { 
+index.search(query, {
     pluck: "title",
     enrich: true
 });
@@ -693,7 +584,7 @@ Like the property `index` within a document descriptor just define a property `t
 
 ```js
 const index = new Document({
-    document: { 
+    document: {
         id: "id",
         tag: "species",
         index: "content"
@@ -723,7 +614,7 @@ You can perform a tag-specific search by:
 
 ```js
 index.search(query, {
-    tag: { species: "fish" } 
+    tag: { species: "fish" }
 });
 ```
 
@@ -806,7 +697,7 @@ Get entries of multiple tags (intersection):
 ```js
 const result = index.search({
     //enrich: true, // enrich documents
-    tag: { 
+    tag: {
         "genres": ["Documentary", "Short"],
         "startYear": "1894"
     }
@@ -817,7 +708,7 @@ Combine tags with queries (intersection):
 ```js
 const result = index.search({
     query: "Carmen", // forward tokenizer
-    tag: { 
+    tag: {
         "genres": ["Documentary", "Short"],
         "startYear": "1894"
     }
@@ -853,7 +744,7 @@ This will add the whole original content to the store:
 
 ```js
 const index = new Document({
-    document: { 
+    document: {
         index: "content",
         store: true
     }
@@ -907,9 +798,9 @@ A short example of configuring a document store:
 
 ```js
 const index = new Document({
-    document: { 
+    document: {
         index: "content",
-        store: ["author", "email"] 
+        store: ["author", "email"]
     }
 });
 
@@ -1013,7 +904,7 @@ const index = new Document({
             field: "fullname",
             custom: function(data){
                 // return custom string
-                return data.firstname + " " + 
+                return data.firstname + " " +
                        data.lastname;
             }
         },{

--- a/doc/encoder.md
+++ b/doc/encoder.md
@@ -101,7 +101,7 @@ const encoder = new Encoder({
 Instead of using `include` or `exclude` you can pass a regular expression or a string to the field `split`:
 
 ```js
-const encoder = new Encoder({ 
+const encoder = new Encoder({
     split: /\s+/
 });
 ```
@@ -109,7 +109,7 @@ const encoder = new Encoder({
 E.g. this split configuration will tokenize every symbol/char from a content:
 
 ```js
-const encoder = new Encoder({ 
+const encoder = new Encoder({
     split: ""
 });
 ```
@@ -137,7 +137,7 @@ Further reading: [Encoder Processing Workflow](#encoder-processing-workflow)
 Assign an encoder to an index:
 
 ```js
-const index = new Index({ 
+const index = new Index({
     encoder: encoder
 });
 ```
@@ -251,264 +251,64 @@ encoder.addFilter(function(str){
 Shortcut for just assigning one encoder configuration to an index:
 
 ```js
-const index = new Index({ 
+const index = new Index({
     encoder: Charset.Normalize
 });
 ```
 
 ## Encoder Options
 
-<table>
-    <tr></tr>
-    <tr>
-        <td>Option</td>
-        <td>Values</td>
-        <td>Description</td>
-        <td>Default</td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td colspan="4">You can just choose one of those 3 options:</td>
-    </tr>
-    <tr>
-        <td><code>include</code></td>
-        <td>
-            <a href="#encoder-split-options">Encoder Split Options</a>
-        </td>
-        <td>Define which of the string contents should be included (inclusion properties defaults to false)</td>
-        <td>{ letter: true, number: true }</td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td><code>exclude</code></td>
-        <td>
-            <a href="#encoder-split-options">Encoder Split Options</a>
-        </td>
-        <td>Define which of the string contents should be excluded (exclusion properties defaults to true)</td>
-        <td>false</td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td><code>split</code></td>
-        <td>
-            false<br>
-            RegExp<br>
-            String<br>
-            <a href="#encoder-split-options">Encoder Split Options</a>
-        </td>
-        <td>
-            The expression used to split the content into terms
-        </td>
-        <td>→ include { letter: true, number: true }</td>
-    </tr>
-    <tr>
-        <td colspan="4">Other options:</td>
-    </tr>
-    <tr>
-        <td><code>dedupe</code></td>
-        <td>
-            Boolean
-        </td>
-        <td>Deduplicate consecutive letters, e.g. "missing" to "mising"</td>
-        <td>true</td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td><code>numeric</code></td>
-        <td>
-            Boolean
-        </td>
-        <td>By default, the extended numeric support (Triplets) inherits from chosen <a href="#encoder-split-options">Encoder Split Options</a>. You probably might want to disable Triplets to get a more exact result (fewer entries) in some cases.</td>
-        <td>true</td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td><code>minlength</code></td>
-        <td>
-            Number
-        </td>
-        <td>Set the minimum term length which should be added to the index. This limit does not apply to the <code>forward</code> tokenizer. You still get results when just typing "f" on a term "flexsearch" when e.g. <code>minlength: 4</code> was used.</td>
-        <td>1</td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td><code>maxlength</code></td>
-        <td>
-            Number
-        </td>
-        <td>Set the maximum term length which should be added to the index. Larger content will drop.</td>
-        <td>1</td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td><code>rtl</code></td>
-        <td>
-            Boolean
-        </td>
-        <td>Force Right-To-Left encoding (you should just apply this when the string content was not already encoded as RTL)</td>
-        <td>false</td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td><code>normalize</code></td>
-        <td>
-            <code>true</code> enable normalization (default)<br>
-            <code>false</code> disable normalization<br>
-            <code>function(str) => str</code> custom function
-        </td>
-        <td>The normalization stage will apply basic charset normalization e.g. by replacing "é" to "e"</td>
-        <td>true</td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td><code>prepare</code></td>
-        <td>
-            <code>function(str) => str</code> custom function
-        </td>
-        <td>The preparation stage is a custom function direct followed when normalization was done</td>
-        <td>false</td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td><code>finalize</code></td>
-        <td>
-            <code>function([str]) => [str]</code> custom function
-        </td>
-        <td>The finalization stage is a custom function executed at the last task in the encoding pipeline (here it gets an array of tokens and need to return an array of tokens)</td>
-        <td>false</td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td><code>filter</code></td>
-        <td>
-            <code>Set(["and", "to", "be"])</code><br>
-            <code>function(str) => bool</code> custom function<h2></h2>
-            <code>encoder.addFilter("and")</code>
-        </td>
-        <td>Stop-word filter is like a blacklist of words to be filtered out from indexing at all (e.g. "and", "to" or "be"). This is also very useful when using <a href="../README.md#context-search">Context Search</a></td>
-        <td>false</td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td><code>stemmer</code></td>
-        <td>
-            <code>Map([["ing", ""], ["ies", "y"]])</code><h2></h2>
-            <code>encoder.addStemmer("ing", "")</code>
-        </td>
-        <td>Stemmer will normalize several linguistic mutations of the same word (e.g. "run" and "running", or "property" and "properties"). This is also very useful when using <a href="../README.md#context-search">Context Search</a></td>
-        <td>false</td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td><code>mapper</code></td>
-        <td>
-            <code>Map([["é", "e"], ["ß", "ss"]])</code><h2></h2>
-            <code>encoder.addMapper("é", "e")</code>
-        </td>
-        <td>Mapper will replace a single char (e.g. "é" into "e")</td>
-        <td>false</td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td><code>matcher</code></td>
-        <td>
-            <code>Map([["and", "&"], ["usd", "$"]])</code><h2></h2>
-            <code>encoder.addMatcher("and", "&")</code>
-        </td>
-        <td>Matcher will do same as Mapper but instead of single chars it will replace char sequences</td>
-        <td>false</td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td><code>replacer</code></td>
-        <td>
-            <code>[/[^a-z0-9]/g, "", /([^aeo])h(.)/g, "$1$2"])</code><h2></h2>
-            <code>encoder.addReplacer(/[^a-z0-9]/g, "")</code>
-        </td>
-        <td>Replacer takes custom regular expressions and couldn't get optimized in the same way as Mapper or Matcher. You should take this as the last option when no other replacement can do the same.</td>
-        <td>false</td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td><code>cache</code></td>
-        <td>
-            Boolean
-        </td>
-        <td>In some very rare situations (large consecutive content with high cardinality) it might be useful to disable the internal event-loop-cache</td>
-        <td>true</td>
-    </tr>
-</table>
+|        |        |             |         |
+|--------|--------|-------------|---------|
+| Option | Values | Description | Default |
+| You can just choose one of those 3 options: |
+| include | Encoder Split Options | Define which of the string contents should be included (inclusion properties defaults to false) | { letter: true, number: true } |
+| exclude | Encoder Split Options | Define which of the string contents should be excluded (exclusion properties defaults to true) | false |
+| split | false
+            RegExp
+            String
+            Encoder Split Options | The expression used to split the content into terms | → include { letter: true, number: true } |
+| Other options: |
+| dedupe | Boolean | Deduplicate consecutive letters, e.g. "missing" to "mising" | true |
+| numeric | Boolean | By default, the extended numeric support (Triplets) inherits from chosen Encoder Split Options. You probably might want to disable Triplets to get a more exact result (fewer entries) in some cases. | true |
+| minlength | Number | Set the minimum term length which should be added to the index. This limit does not apply to the forward tokenizer. You still get results when just typing "f" on a term "flexsearch" when e.g. minlength: 4 was used. | 1 |
+| maxlength | Number | Set the maximum term length which should be added to the index. Larger content will drop. | 1 |
+| rtl | Boolean | Force Right-To-Left encoding (you should just apply this when the string content was not already encoded as RTL) | false |
+| normalize | true enable normalization (default)
+            false disable normalization
+            function(str) => str custom function | The normalization stage will apply basic charset normalization e.g. by replacing "é" to "e" | true |
+| prepare | function(str) => str custom function | The preparation stage is a custom function direct followed when normalization was done | false |
+| finalize | function([str]) => [str] custom function | The finalization stage is a custom function executed at the last task in the encoding pipeline (here it gets an array of tokens and need to return an array of tokens) | false |
+| filter | Set(["and", "to", "be"])
+            function(str) => bool custom function
+            encoder.addFilter("and") | Stop-word filter is like a blacklist of words to be filtered out from indexing at all (e.g. "and", "to" or "be"). This is also very useful when using Context Search | false |
+| stemmer | Map([["ing", ""], ["ies", "y"]])
+            encoder.addStemmer("ing", "") | Stemmer will normalize several linguistic mutations of the same word (e.g. "run" and "running", or "property" and "properties"). This is also very useful when using Context Search | false |
+| mapper | Map([["é", "e"], ["ß", "ss"]])
+            encoder.addMapper("é", "e") | Mapper will replace a single char (e.g. "é" into "e") | false |
+| matcher | Map([["and", "&"], ["usd", "$"]])
+            encoder.addMatcher("and", "&") | Matcher will do same as Mapper but instead of single chars it will replace char sequences | false |
+| replacer | [/[^a-z0-9]/g, "", /([^aeo])h(.)/g, "$1$2"])
+            encoder.addReplacer(/[^a-z0-9]/g, "") | Replacer takes custom regular expressions and couldn't get optimized in the same way as Mapper or Matcher. You should take this as the last option when no other replacement can do the same. | false |
+| cache | Boolean | In some very rare situations (large consecutive content with high cardinality) it might be useful to disable the internal event-loop-cache | true |
+
 
 > [!TIP]
 > The methods `.addMapper()`, `.addMatcher()` and `.addReplacer()` might be confusing. For this reason they will automatically resolve to the right one when just using the same method for every rule. You can simplify this e.g. by just use `.addReplacer()` for each of this 3 rules.
 
 ### Encoder Split Options
 
-<table>
-    <tr></tr>
-    <tr>
-        <td>Option</td>
-        <td>Values</td>
-        <td>Description</td>
-        <td>Default</td>
-    </tr>
-    <tr>
-        <td><code>letter</code></td>
-        <td>
-            Boolean
-        </td>
-        <td>Toggle inclusion of letters on/off</td>
-        <td>true</td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td><code>number</code></td>
-        <td>
-            Boolean
-        </td>
-        <td>Toggle inclusion of numerics on/off</td>
-        <td>true</td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td><code>symbol</code></td>
-        <td>
-            Boolean
-        </td>
-        <td>Toggle inclusion of symbols on/off</td>
-        <td>false</td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td><code>punctuation</code></td>
-        <td>
-            Boolean
-        </td>
-        <td>
-            Toggle inclusion of punctuation on/off
-        </td>
-        <td>false</td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td><code>control</code></td>
-        <td>
-            Boolean
-        </td>
-        <td>Toggle inclusion of control chars on/off</td>
-        <td>false</td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td><code>char</code></td>
-        <td>
-            String<br>
-            Array[String]
-        </td>
-        <td>Toggle inclusion of specific chars on/off</td>
-        <td>false</td>
-    </tr>
-</table>
+|             |         |                                          |         |
+|-------------|---------|------------------------------------------|---------|
+| Option      | Values  | Description                              | Default |
+| letter      | Boolean | Toggle inclusion of letters on/off       | true    |
+| number      | Boolean | Toggle inclusion of numerics on/off      | true    |
+| symbol      | Boolean | Toggle inclusion of symbols on/off       | false   |
+| punctuation | Boolean | Toggle inclusion of punctuation on/off   | false   |
+| control     | Boolean | Toggle inclusion of control chars on/off | false   |
+| char | String
+            Array[String] | Toggle inclusion of specific chars on/off | false |
+
 
 ## Custom Encoder
 

--- a/doc/persistent.md
+++ b/doc/persistent.md
@@ -136,100 +136,17 @@ await index.commit();
 
 The benchmark was measured in "terms per second".
 
-<table>
-    <tr>
-        <th align="left">Store</th>
-        <th>Add</th>
-        <th>Search 1</th>
-        <th>Search N</th>
-        <th>Replace</th>
-        <th>Remove</th>
-        <th>Not Found</th>
-        <th>Scaling</th>
-    </tr>
-    <tr>
-        <td></td>
-        <td align="right"><sub>terms per sec</sub></td>
-        <td align="right"><sub>terms per sec</sub></td>
-        <td align="right"><sub>terms per sec</sub></td>
-        <td align="right"><sub>terms per sec</sub></td>
-        <td align="right"><sub>terms per sec</sub></td>
-        <td align="right"><sub>terms per sec</sub></td>
-        <td></td>
-    </tr>
-    <!--
-    <tr>
-        <td align="left">Memory</td>
-        <td align="right">28,345,405</td>
-        <td align="right">65,180,102</td>
-        <td align="right">12,098,298</td>
-        <td align="right">19,099,981</td>
-        <td align="right">36,164,827</td>
-        <td align="right">143,369,175</td>
-        <td align="right">No</td>
-    </tr>
-    -->
-    <tr>
-        <td align="left">IndexedDB</td>
-        <td align="right">123,298</td>
-        <td align="right">83,823</td>
-        <td align="right">62,370</td>
-        <td align="right">57,410</td>
-        <td align="right">171,053</td>
-        <td align="right">425,744</td>
-        <td align="right">No</td>
-    </tr>
-    <tr>
-        <td align="left">Redis</td>
-        <td align="right">1,566,091</td>
-        <td align="right">201,534</td>
-        <td align="right">859,463</td>
-        <td align="right">117,013</td>
-        <td align="right">129,595</td>
-        <td align="right">875,526</td>
-        <td align="right">Yes</td>
-    </tr>
-    <tr>
-        <td align="left">Sqlite</td>
-        <td align="right">269,812</td>
-        <td align="right">29,627</td>
-        <td align="right">129,735</td>
-        <td align="right">174,445</td>
-        <td align="right">1,406,553</td>
-        <td align="right">122,566</td>
-        <td align="right">No</td>
-    </tr>
-    <tr>
-        <td align="left">Postgres</td>
-        <td align="right">354,894</td>
-        <td align="right">24,329</td>
-        <td align="right">76,189</td>
-        <td align="right">324,546</td>
-        <td align="right">3,702,647</td>
-        <td align="right">50,305</td>
-        <td align="right">Yes</td>
-    </tr>
-    <tr>
-        <td align="left">MongoDB</td>
-        <td align="right">515,938</td>
-        <td align="right">19,684</td>
-        <td align="right">81,558</td>
-        <td align="right">243,353</td>
-        <td align="right">485,192</td>
-        <td align="right">67,751</td>
-        <td align="right">Yes</td>
-    </tr>
-    <tr>
-        <td align="left">Clickhouse</td>
-        <td align="right">1,436,992</td>
-        <td align="right">11,507</td>
-        <td align="right">22,196</td>
-        <td align="right">931,026</td>
-        <td align="right">3,276,847</td>
-        <td align="right">16,644</td>
-        <td align="right">Yes</td>
-    </tr>
-</table>
+| Store      | Add           | Search 1      | Search N      | Replace       | Remove        | Not Found     | Scaling |
+|------------|---------------|---------------|---------------|---------------|---------------|---------------|---------|
+|            | terms per sec | terms per sec | terms per sec | terms per sec | terms per sec | terms per sec |         |
+| Memory     | 28,345,405    | 65,180,102    | 12,098,298    | 19,099,981    | 36,164,827    | 143,369,175   | No      |
+| IndexedDB  | 123,298       | 83,823        | 62,370        | 57,410        | 171,053       | 425,744       | No      |
+| Redis      | 1,566,091     | 201,534       | 859,463       | 117,013       | 129,595       | 875,526       | Yes     |
+| Sqlite     | 269,812       | 29,627        | 129,735       | 174,445       | 1,406,553     | 122,566       | No      |
+| Postgres   | 354,894       | 24,329        | 76,189        | 324,546       | 3,702,647     | 50,305        | Yes     |
+| MongoDB    | 515,938       | 19,684        | 81,558        | 243,353       | 485,192       | 67,751        | Yes     |
+| Clickhouse | 1,436,992     | 11,507        | 22,196        | 931,026       | 3,276,847     | 16,644        | Yes     |
+
 
 __Search 1:__ Single term query<br>
 __Search N:__ Multi term query (Context-Search)

--- a/doc/resolver.md
+++ b/doc/resolver.md
@@ -3,7 +3,7 @@
 Retrieve an unresolved result:
 
 ```js
-const raw = index.search("a short query", { 
+const raw = index.search("a short query", {
     resolve: false
 });
 ```
@@ -29,7 +29,7 @@ raw.and( ... )
 The default resolver:
 
 ```js
-const raw = index.search("a short query", { 
+const raw = index.search("a short query", {
     resolve: false
 });
 const result = raw.resolve();
@@ -53,7 +53,7 @@ The basic concept explained:
 
 ```js
 // 1. get one or multiple unresolved results
-const raw1 = index.search("a short query", { 
+const raw1 = index.search("a short query", {
     resolve: false
 });
 const raw2 = index.search("another query", {
@@ -149,188 +149,47 @@ const result = new Resolver({
 
 ## Resolver Tasks
 
-<table>
-    <tr></tr>
-    <tr>
-        <td>Method</td>
-        <td>Description</td>
-        <td>Return</td>
-    </tr>
-    <tr>
-        <td>
-            <code>.and(options,...)</code><br>
-            <code>.or(options,...)</code><br>
-            <code>.not(options,...)</code><br>
-            <code>.xor(options,...)</code>
-        </td>
-        <td>Apply an operation</td>
-        <td>Returns a <code>Resolver</code> when <code>resolve</code> was not set to <code>false</code> within the options, otherwise it returns the result (or promise in async context).</td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td>
-            <code>.limit(number)</code><br>
-            <code>.offset(number)</code><br>
-            <code>.boost(number)</code>
-        </td>
-        <td>Apply boost, limit and offset to the result</td>
-        <td>Returns a <code>Resolver</code></td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td>
-            <code>.resolve(options)</code>
-        </td>
-        <td>Resolve results</td>
-        <td>Returns the final result or promise in async context (can't be executed twice)</td>
-    </tr>
-</table>
+|        |             |        |
+|--------|-------------|--------|
+| Method | Description | Return |
+| .and(options,...)
+            .or(options,...)
+            .not(options,...)
+            .xor(options,...) | Apply an operation | Returns a Resolver when resolve was not set to false within the options, otherwise it returns the result (or promise in async context). |
+| .limit(number)
+            .offset(number)
+            .boost(number) | Apply boost, limit and offset to the result | Returns a Resolver |
+| .resolve(options) | Resolve results | Returns the final result or promise in async context (can't be executed twice) |
+
 
 
 ## Resolver Options
 
-<table>
-    <tr></tr>
-    <tr>
-        <td>Option</td>
-        <td>Values</td>
-        <td>Description</td>
-        <td>Default</td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td colspan="4">Resolver Task Options:</td>
-    </tr>
-    <tr>
-        <td><code>query</code></td>
-        <td>
-            String
-        </td>
-        <td>The search query</td>
-        <td></td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td><code>index</code></td>
-        <td>
-            <code>Index</code><br>
-            <code>Document</code>
-        </td>
-        <td>Assign the index where the query should be applied to</td>
-        <td></td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td><code>suggest</code></td>
-        <td>
-            Boolean
-        </td>
-        <td>Enables <a href="../README.md#suggestions">suggestions</a> in results</td>
-        <td>false</td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td><code>boost</code></td>
-        <td>
-            Number
-        </td>
-        <td>Boost or reduce the score of this query</td>
-        <td>0</td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td><code>async</code></td>
-        <td>
-            Boolean
-        </td>
-        <td>Use a <a href="#using-async-queries-incl-runtime-balancer">parallel processing workflow</a></td>
-        <td>false</td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td><code>queue</code></td>
-        <td>
-            Boolean
-        </td>
-        <td>Use a <a href="#queuing-async-queries">queued processing workflow</a></td>
-        <td>false</td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td>
-            <code>and</code><br>
-            <code>or</code><br>
-            <code>not</code><br>
-            <code>xor</code><br>
-        </td>
-        <td>
-            Array&lt;<a href="#resolver-options">ResolverOptions</a>&gt;
-        </td>
-        <td>Apply nested queries</td>
-        <td></td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td><code>resolve</code></td>
-        <td>
-            Boolean
-        </td>
-        <td>
-            Resolve the result immediately or not. When set to <code>true</code> all final resolve options are also allowed and there can't exist any further resolver operations.
-        </td>
-        <td>false</td>
-    </tr>
-    <tr>
-        <td colspan="4">Document Resolver Options:</td>
-    </tr>
-    <tr>
-        <td><code>field</code><br><code>pluck</code></td>
-        <td>
-            String
-        </td>
-        <td>Select the Document field on which the query should apply to.</td>
-        <td></td>
-    </tr>
-    <tr>
-        <td colspan="4">Final Resolve Options:</td>
-    </tr>
-    <tr>
-        <td><code>enrich</code></td>
-        <td>
-            Boolean
-        </td>
-        <td>Enrich IDs from the results with the corresponding documents (for Document Indexes only)</td>
-        <td>true</td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td><code>highlight</code></td>
-        <td>
-            <a href="./result-highlighting.md#highlighting-options">Highlighting Options</a><br>
-            String
-        </td>
-        <td>Highlight query matches in the result (for Document Indexes only)</td>
-        <td></td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td><code>limit</code></td>
-        <td>
-            Number
-        </td>
-        <td>Sets the limit of results</td>
-        <td>100</td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td><code>offset</code></td>
-        <td>
-            Boolean
-        </td>
-        <td>Apply offset (skip items)</td>
-        <td>0</td>
-    </tr>
-</table>
+|        |        |             |         |
+|--------|--------|-------------|---------|
+| Option | Values | Description | Default |
+| Resolver Task Options: |
+| query | String | The search query |  |
+| index | Index
+            Document | Assign the index where the query should be applied to |  |
+| suggest | Boolean | Enables suggestions in results | false |
+| boost | Number | Boost or reduce the score of this query | 0 |
+| async | Boolean | Use a parallel processing workflow | false |
+| queue | Boolean | Use a queued processing workflow | false |
+| and
+            or
+            not
+            xor | Array&lt;ResolverOptions&gt; | Apply nested queries |  |
+| resolve | Boolean | Resolve the result immediately or not. When set to true all final resolve options are also allowed and there can't exist any further resolver operations. | false |
+| Document Resolver Options: |
+| fieldpluck | String | Select the Document field on which the query should apply to. |  |
+| Final Resolve Options: |
+| enrich | Boolean | Enrich IDs from the results with the corresponding documents (for Document Indexes only) | true |
+| highlight | Highlighting Options
+            String | Highlight query matches in the result (for Document Indexes only) |  |
+| limit | Number | Sets the limit of results | 100 |
+| offset | Boolean | Apply offset (skip items) | 0 |
+
 
 ### Using Cached Queries
 
@@ -341,7 +200,7 @@ const result = new Resolver({
     query: "a query",
     cache: true
 })
-.and({ 
+.and({
     query: "another query",
     cache: true
 })
@@ -361,7 +220,7 @@ const resolver = new Resolver({
     query: "a query",
     async: true
 })
-.and({ 
+.and({
     query: "another query",
     async: true
 })
@@ -380,7 +239,7 @@ const resolver = new Resolver({
     query: "a query",
     async: true
 })
-.and({ 
+.and({
     query: "another query",
     async: true
 });
@@ -403,7 +262,7 @@ const resolver = await new Resolver({
     query: "a query",
     async: true
 })
-.and({ 
+.and({
     query: "another query",
     queue: true
 })
@@ -418,7 +277,7 @@ When tasks are processed consecutively, it will skip specific resolver stages wh
 
 ### Compare Parallel VS. Consecutive
 
-When using the parallel workflow by passing `{ async: true }`, all resolver stages will send their requests (including nested tasks) to the DB immediately and calculate the results in the right order as soon as the request resolves. When the overall workload of your applications has some free resources, a parallel request workflow improves performance compared to the consecutive counterpart. 
+When using the parallel workflow by passing `{ async: true }`, all resolver stages will send their requests (including nested tasks) to the DB immediately and calculate the results in the right order as soon as the request resolves. When the overall workload of your applications has some free resources, a parallel request workflow improves performance compared to the consecutive counterpart.
 
 <br><img src="resolver-parallel.svg" style="width: 780px; max-width: 100%">
 
@@ -439,7 +298,7 @@ function CustomResolver(raw){
     return output;
 }
 
-const result = index.search("a short query", { 
+const result = index.search("a short query", {
     resolve: CustomResolver
 });
 ```

--- a/doc/result-highlighting.md
+++ b/doc/result-highlighting.md
@@ -10,7 +10,7 @@ Alternatively you can simply upgrade id-content-pairs to a flat document when ca
 // 1. create the document index
 const index = new Document({
   document: {
-    // using store is required  
+    // using store is required
     store: true,
     index: [{
       field: "title",
@@ -33,7 +33,7 @@ index.add({
 // 3. perform a query
 const result = index.search({
   query: "karmen or clown or not found",
-  // also get results when query has no exact match  
+  // also get results when query has no exact match
   suggest: true,
   // use highlighting options or pass a template, where $1 is
   // a placeholder for the matched partial
@@ -60,116 +60,26 @@ There are several options to customize result highlighting.
 
 ### Highlighting Options
 
-<table>
-    <tr></tr>
-    <tr>
-        <td>Option</td>
-        <td>Values</td>
-        <td>Description</td>
-        <td>Default</td>
-    </tr>
-    <tr>
-        <td><code>template</code></td>
-        <td>
-            String
-        </td>
-        <td>The template to be applied on matches (e.g. <code>"&lt;b>$1&lt;/b>"</code>), where <code>$1</code> is a placeholder for the matched partial</td>
-        <td style="font-style: italic">(mandatory)</td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td><code>boundary</code></td>
-        <td>
-            <a href="#highlighting-boundary-options">Boundary Options</a><br>
-            Number
-        </td>
-        <td>Limit the total length of highlighted content (add ellipsis by default). The template markup does not stack to the total length.</td>
-        <td><code>false</code></td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td><code>ellipsis</code></td>
-        <td>
-            <a href="#highlighting-ellipsis-options">Ellipsis Options</a><br>
-            Boolean<br>
-            String
-        </td>
-        <td>
-            Define a custom ellipsis or disable
-        </td>
-        <td><code>"..."</code></td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td><code>merge</code></td>
-        <td>
+|          |        |                                                                                                                   |             |
+|----------|--------|-------------------------------------------------------------------------------------------------------------------|-------------|
+| Option   | Values | Description                                                                                                       | Default     |
+| template | String | The template to be applied on matches (e.g. "&lt;b>$1&lt;/b>"), where $1 is a placeholder for the matched partial | (mandatory) |
+| boundary | Boundary Options
+            Number | Limit the total length of highlighted content (add ellipsis by default). The template markup does not stack to the total length. | false |
+| ellipsis | Ellipsis Options
             Boolean
-        </td>
-        <td>Wrap consecutive matches by just a single template</td>
-        <td><code>false</code></td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td><code>clip</code></td>
-        <td>
-            Boolean
-        </td>
-        <td>Allow to clip terms</td>
-        <td><code>true</code></td>
-    </tr>
-    <tr>
-        <td colspan="4"><a id="highlighting-boundary-options"></a>Boundary Options</td>
-    </tr>
-    <tr>
-        <td><code>boundary.total</code></td>
-        <td>
-            Number
-        </td>
-        <td>Limit the total length of highlighted content</td>
-        <td><code>false</code></td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td><code>boundary.before</code></td>
-        <td>
-            Number
-        </td>
-        <td>Limit the length of content before highlighted parts</td>
-        <td style="font-style: italic">(auto)</td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td><code>boundary.after</code></td>
-        <td>
-            Number
-        </td>
-        <td>Limit the length of content after highlighted parts</td>
-        <td style="font-style: italic">(auto)</td>
-    </tr>
-    <tr>
-        <td colspan="4"><a id="highlighting-ellipsis-options"></a>Ellipsis Options</td>
-    </tr>
-    <tr>
-        <td><code>ellipsis.template</code></td>
-        <td>
-            String
-        </td>
-        <td>The template to be applied on ellipsis (e.g. <code>"&lt;i>$1&lt;/i>"</code>), where <code>$1</code> is a placeholder for the ellipsis</td>
-        <td style="font-style: italic">(mandatory)</td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td><code>ellipsis.pattern</code></td>
-        <td>
-            Boolean<br>
-            String
-        </td>
-        <td>
-            Define a custom ellipsis or disable
-        </td>
-        <td><code>"..."</code></td>
-    </tr>
-</table>
+            String | Define a custom ellipsis or disable | "..." |
+| merge | Boolean | Wrap consecutive matches by just a single template | false |
+| clip | Boolean | Allow to clip terms | true |
+| Boundary Options |
+| boundary.total | Number | Limit the total length of highlighted content | false |
+| boundary.before | Number | Limit the length of content before highlighted parts | (auto) |
+| boundary.after | Number | Limit the length of content after highlighted parts | (auto) |
+| Ellipsis Options |
+| ellipsis.template | String | The template to be applied on ellipsis (e.g. "&lt;i>$1&lt;/i>"), where $1 is a placeholder for the ellipsis | (mandatory) |
+| ellipsis.pattern | Boolean
+            String | Define a custom ellipsis or disable | "..." |
+
 
 ### Boundaries & Alignment
 
@@ -209,7 +119,7 @@ const result = index.search({
 });
 ```
 > The highlight markup does not stack to the total length.
-> 
+>
 Result:
 ```js
 "...um dolor <b>sit</b> <b>amet</b> consetet..."
@@ -282,12 +192,12 @@ const result = index.search({
   highlight: {
     template: "<b>$1</b>",
     boundary: {
-      // length before match  
+      // length before match
       before: 3,
-      // length after match  
+      // length after match
       after: 15,
-      // overall length  
-      total: 32  
+      // overall length
+      total: 32
     }
   }
 });

--- a/doc/worker.md
+++ b/doc/worker.md
@@ -17,21 +17,21 @@ Documents will create worker automatically for each field by just apply the opti
 ```js
 const index = new Document({
     worker: true,
-    document: { 
+    document: {
         id: "id",
         index: ["name", "title"],
         tag: ["cat"]
     }
 });
 
-index.add({ 
-    id: 1, cat: "catA", name: "Tom", title: "some" 
+index.add({
+    id: 1, cat: "catA", name: "Tom", title: "some"
 }).add({
     id: 2, cat: "catA", name: "Ben", title: "title"
-}).add({ 
+}).add({
     id: 3, cat: "catB", name: "Max", title: "to"
-}).add({ 
-    id: 4, cat: "catB", name: "Tim", title: "index"" 
+}).add({
+    id: 4, cat: "catB", name: "Tim", title: "index""
 });
 ```
 
@@ -105,31 +105,13 @@ const index = new Worker({ options });
 
 > Worker-Index Options extends the default [Index Options](../README.md#index-options), you can apply also.
 
-<table>
-    <tr></tr>
-    <tr>
-        <td>Option</td>
-        <td>Values</td>
-        <td>Description</td>
-    </tr>
-    <tr>
-        <td>config</td>
-        <td>String</td>
-        <td>Either the absolute URL to the config file when used in Browser context (should match the Same-Origin-Policy) or the filepath to the configuration file when used in Node.js context</td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td>export</td>
-        <td>function</td>
-        <td>The export handler function. Read more about <a href="export-import.md">Export</a></td>
-    </tr>
-    <tr></tr>
-    <tr>
-        <td>import</td>
-        <td>function</td>
-        <td>The export handler function. Read more about <a href="export-import.md">Import</a></td>
-    </tr>
-</table>
+|        |          |                                                                                                                                                                                      |
+|--------|----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Option | Values   | Description                                                                                                                                                                          |
+| config | String   | Either the absolute URL to the config file when used in Browser context (should match the Same-Origin-Policy) or the filepath to the configuration file when used in Node.js context |
+| export | function | The export handler function. Read more about Export                                                                                                                                  |
+| import | function | The export handler function. Read more about Import                                                                                                                                  |
+
 
 ## Extern Worker Configuration
 


### PR DESCRIPTION
This pull request updates the documentation by replacing HTML tables with Markdown tables for configuration options in the documentation files. The main goal is to improve readability and maintain consistency across the documentation. The changes affect several docs related to custom builds, document search, and encoder options.

Documentation formatting improvements:

* Replaced HTML tables with Markdown tables in `doc/custom-builds.md`, `doc/document-search.md`, and `doc/encoder.md` for build flags, document options, search options, document descriptors, field options, encoder options, and encoder split options. This makes the documentation easier to read and maintain. [[1]](diffhunk://#diff-0e03b0e341bd2659688cc76071e69624a19dd7ff1d0f118edfa2c3c1cc115ca6L57-R82) [[2]](diffhunk://#diff-84ba549cd405c862a8c8864ef0bf5ff8e0f01c86f2ff934c9564a8ac81939a77L21-R66) [[3]](diffhunk://#diff-98daecedac7ed846a73fa05bb94bfdd1f30f89fc5e7f5f6b73ad883668297c9dL261-R311)