### PR TITLE
fix npm run build:lang

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
         "babel-plugin-transform-property-literals": "^6.9.4",
         "babel-plugin-transform-simplify-comparison-operators": "^6.9.4",
         "babel-plugin-transform-undefined-to-void": "^6.9.4",
-        "google-closure-compiler": "^20250520.0.0",
+        "google-closure-compiler": "^20260302.0.0",
         "rollup": "^4.35.0"
       }
     },
@@ -1820,16 +1820,16 @@
       }
     },
     "node_modules/google-closure-compiler": {
-      "version": "20250520.0.0",
-      "resolved": "https://registry.npmjs.org/google-closure-compiler/-/google-closure-compiler-20250520.0.0.tgz",
-      "integrity": "sha512-vXY043D00zCv3XGwmSUAWJAsBhe1QOToMIxrIj0YGYbMCjimDUJyqjeNoD/Vsrm4MkSZzjPwrhm35xI2XrXXwA==",
+      "version": "20260302.0.0",
+      "resolved": "https://registry.npmjs.org/google-closure-compiler/-/google-closure-compiler-20260302.0.0.tgz",
+      "integrity": "sha512-pMfk6l5E4RQ2IFZndWoegEkQtAeN4Ikdc9bKkKWbKuNiGZXjy0why1pHdjoVWlPTyxhtCknL3i6c0kgUOmmmaQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "chalk": "5.x",
-        "google-closure-compiler-java": "^20250520.0.0",
-        "minimist": "1.x",
-        "vinyl": "3.x",
+        "chalk": "^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 <5.6.1 || ^5.6.2 >5.6.1",
+        "google-closure-compiler-java": "^20260302.0.0",
+        "minimist": "^1.0.0",
+        "vinyl": "^3.0.1",
         "vinyl-sourcemaps-apply": "^0.2.0"
       },
       "bin": {
@@ -1839,23 +1839,23 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "google-closure-compiler-linux": "^20250520.0.0",
-        "google-closure-compiler-linux-arm64": "^20250520.0.0",
-        "google-closure-compiler-macos": "^20250520.0.0",
-        "google-closure-compiler-windows": "^20250520.0.0"
+        "google-closure-compiler-linux": "^20260302.0.0",
+        "google-closure-compiler-linux-arm64": "^20260302.0.0",
+        "google-closure-compiler-macos": "^20260302.0.0",
+        "google-closure-compiler-windows": "^20260302.0.0"
       }
     },
     "node_modules/google-closure-compiler-java": {
-      "version": "20250520.0.0",
-      "resolved": "https://registry.npmjs.org/google-closure-compiler-java/-/google-closure-compiler-java-20250520.0.0.tgz",
-      "integrity": "sha512-WP+zVU3ifkXIS01HwCVuSNHEYSgLjulA/JSYa8C0yswASP1fec0FqYuQZ3F2i+zScwMw60XkywiQvCh5Ftnp/g==",
+      "version": "20260302.0.0",
+      "resolved": "https://registry.npmjs.org/google-closure-compiler-java/-/google-closure-compiler-java-20260302.0.0.tgz",
+      "integrity": "sha512-IJlznGrDB91o0csYhCI3fDcbxyLotZbS10S8xGM1yeb0cGM1lhKlF2bNXMGu7FW9AZhnhCsCuow19t1EO6V82A==",
       "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/google-closure-compiler-linux": {
-      "version": "20250520.0.0",
-      "resolved": "https://registry.npmjs.org/google-closure-compiler-linux/-/google-closure-compiler-linux-20250520.0.0.tgz",
-      "integrity": "sha512-GNWPUKq8PhHagc31+WntL27+JskkZ7wvEWKQ4qrDXWqItiOpaUfnrDjHhp1k7mUrXdKEWV1D7ZiiNA/PwVPKjQ==",
+      "version": "20260302.0.0",
+      "resolved": "https://registry.npmjs.org/google-closure-compiler-linux/-/google-closure-compiler-linux-20260302.0.0.tgz",
+      "integrity": "sha512-r+6XiOvMuvQTKkB/6zouNrFMXBvlnLnxWvDP6U343azfnBw8e54YZ+RZwdiuwzaCRS/OFkhkDoxyZD6cYJK9+w==",
       "cpu": [
         "x32",
         "x64"
@@ -1868,9 +1868,9 @@
       ]
     },
     "node_modules/google-closure-compiler-linux-arm64": {
-      "version": "20250520.0.0",
-      "resolved": "https://registry.npmjs.org/google-closure-compiler-linux-arm64/-/google-closure-compiler-linux-arm64-20250520.0.0.tgz",
-      "integrity": "sha512-4e5h2y7pPuQQjdOYFLiw0bSUVTebwmdhB26W3wZRK+3X3qknW7h/CpCd+/evTv7gvUpZV+9jgs3PLRoE8yGb7g==",
+      "version": "20260302.0.0",
+      "resolved": "https://registry.npmjs.org/google-closure-compiler-linux-arm64/-/google-closure-compiler-linux-arm64-20260302.0.0.tgz",
+      "integrity": "sha512-4B/PojBGe+Iwcql5zGZRHtQ7QNKP+leLPbgIU2dNE9jU9sDE72XJ+3DNFJwR8tewmkq5actvwZVwAwwR8SHsBg==",
       "cpu": [
         "arm64"
       ],
@@ -1882,9 +1882,9 @@
       ]
     },
     "node_modules/google-closure-compiler-macos": {
-      "version": "20250520.0.0",
-      "resolved": "https://registry.npmjs.org/google-closure-compiler-macos/-/google-closure-compiler-macos-20250520.0.0.tgz",
-      "integrity": "sha512-hs5B7ugN5SPMFuULhgVetFS0gNqZSciv73GUfxK2Rh4s6Wz+GxGVRyJOLBXvMtEjRVLp+OtNgzfvYmE8fTpR2Q==",
+      "version": "20260302.0.0",
+      "resolved": "https://registry.npmjs.org/google-closure-compiler-macos/-/google-closure-compiler-macos-20260302.0.0.tgz",
+      "integrity": "sha512-5/VF9hcn5w7sYFOkI5QvmNm/bF7SrHgOWJzg8sC3d93oRvMSRFHY0nZLVcBnC3ntno9Ut3p5H+MdQGu/4H6RmQ==",
       "cpu": [
         "arm64"
       ],
@@ -1896,9 +1896,9 @@
       ]
     },
     "node_modules/google-closure-compiler-windows": {
-      "version": "20250520.0.0",
-      "resolved": "https://registry.npmjs.org/google-closure-compiler-windows/-/google-closure-compiler-windows-20250520.0.0.tgz",
-      "integrity": "sha512-hKfXOixSZl7Dk1epXtwh6yCTQBwSgE70DcuYboYjyMicOr2/bTL3m1+i0YoiQX6NWBsrrCK1D602Ua9tih/F3A==",
+      "version": "20260302.0.0",
+      "resolved": "https://registry.npmjs.org/google-closure-compiler-windows/-/google-closure-compiler-windows-20260302.0.0.tgz",
+      "integrity": "sha512-V1EI7/GTvtYAcedI0Ol8dNGnHHdcQR672xoO80HhG/l3yCftxLJO6tB+Jlvw8UOgyYYkuhXHg9f7HnsbrdTOlw==",
       "cpu": [
         "x32",
         "x64"
@@ -5012,19 +5012,19 @@
       }
     },
     "google-closure-compiler": {
-      "version": "20250520.0.0",
-      "resolved": "https://registry.npmjs.org/google-closure-compiler/-/google-closure-compiler-20250520.0.0.tgz",
-      "integrity": "sha512-vXY043D00zCv3XGwmSUAWJAsBhe1QOToMIxrIj0YGYbMCjimDUJyqjeNoD/Vsrm4MkSZzjPwrhm35xI2XrXXwA==",
+      "version": "20260302.0.0",
+      "resolved": "https://registry.npmjs.org/google-closure-compiler/-/google-closure-compiler-20260302.0.0.tgz",
+      "integrity": "sha512-pMfk6l5E4RQ2IFZndWoegEkQtAeN4Ikdc9bKkKWbKuNiGZXjy0why1pHdjoVWlPTyxhtCknL3i6c0kgUOmmmaQ==",
       "dev": true,
       "requires": {
-        "chalk": "5.x",
-        "google-closure-compiler-java": "^20250520.0.0",
-        "google-closure-compiler-linux": "^20250520.0.0",
-        "google-closure-compiler-linux-arm64": "^20250520.0.0",
-        "google-closure-compiler-macos": "^20250520.0.0",
-        "google-closure-compiler-windows": "^20250520.0.0",
-        "minimist": "1.x",
-        "vinyl": "3.x",
+        "chalk": "^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 <5.6.1 || ^5.6.2 >5.6.1",
+        "google-closure-compiler-java": "^20260302.0.0",
+        "google-closure-compiler-linux": "^20260302.0.0",
+        "google-closure-compiler-linux-arm64": "^20260302.0.0",
+        "google-closure-compiler-macos": "^20260302.0.0",
+        "google-closure-compiler-windows": "^20260302.0.0",
+        "minimist": "^1.0.0",
+        "vinyl": "^3.0.1",
         "vinyl-sourcemaps-apply": "^0.2.0"
       },
       "dependencies": {
@@ -5037,36 +5037,36 @@
       }
     },
     "google-closure-compiler-java": {
-      "version": "20250520.0.0",
-      "resolved": "https://registry.npmjs.org/google-closure-compiler-java/-/google-closure-compiler-java-20250520.0.0.tgz",
-      "integrity": "sha512-WP+zVU3ifkXIS01HwCVuSNHEYSgLjulA/JSYa8C0yswASP1fec0FqYuQZ3F2i+zScwMw60XkywiQvCh5Ftnp/g==",
+      "version": "20260302.0.0",
+      "resolved": "https://registry.npmjs.org/google-closure-compiler-java/-/google-closure-compiler-java-20260302.0.0.tgz",
+      "integrity": "sha512-IJlznGrDB91o0csYhCI3fDcbxyLotZbS10S8xGM1yeb0cGM1lhKlF2bNXMGu7FW9AZhnhCsCuow19t1EO6V82A==",
       "dev": true
     },
     "google-closure-compiler-linux": {
-      "version": "20250520.0.0",
-      "resolved": "https://registry.npmjs.org/google-closure-compiler-linux/-/google-closure-compiler-linux-20250520.0.0.tgz",
-      "integrity": "sha512-GNWPUKq8PhHagc31+WntL27+JskkZ7wvEWKQ4qrDXWqItiOpaUfnrDjHhp1k7mUrXdKEWV1D7ZiiNA/PwVPKjQ==",
+      "version": "20260302.0.0",
+      "resolved": "https://registry.npmjs.org/google-closure-compiler-linux/-/google-closure-compiler-linux-20260302.0.0.tgz",
+      "integrity": "sha512-r+6XiOvMuvQTKkB/6zouNrFMXBvlnLnxWvDP6U343azfnBw8e54YZ+RZwdiuwzaCRS/OFkhkDoxyZD6cYJK9+w==",
       "dev": true,
       "optional": true
     },
     "google-closure-compiler-linux-arm64": {
-      "version": "20250520.0.0",
-      "resolved": "https://registry.npmjs.org/google-closure-compiler-linux-arm64/-/google-closure-compiler-linux-arm64-20250520.0.0.tgz",
-      "integrity": "sha512-4e5h2y7pPuQQjdOYFLiw0bSUVTebwmdhB26W3wZRK+3X3qknW7h/CpCd+/evTv7gvUpZV+9jgs3PLRoE8yGb7g==",
+      "version": "20260302.0.0",
+      "resolved": "https://registry.npmjs.org/google-closure-compiler-linux-arm64/-/google-closure-compiler-linux-arm64-20260302.0.0.tgz",
+      "integrity": "sha512-4B/PojBGe+Iwcql5zGZRHtQ7QNKP+leLPbgIU2dNE9jU9sDE72XJ+3DNFJwR8tewmkq5actvwZVwAwwR8SHsBg==",
       "dev": true,
       "optional": true
     },
     "google-closure-compiler-macos": {
-      "version": "20250520.0.0",
-      "resolved": "https://registry.npmjs.org/google-closure-compiler-macos/-/google-closure-compiler-macos-20250520.0.0.tgz",
-      "integrity": "sha512-hs5B7ugN5SPMFuULhgVetFS0gNqZSciv73GUfxK2Rh4s6Wz+GxGVRyJOLBXvMtEjRVLp+OtNgzfvYmE8fTpR2Q==",
+      "version": "20260302.0.0",
+      "resolved": "https://registry.npmjs.org/google-closure-compiler-macos/-/google-closure-compiler-macos-20260302.0.0.tgz",
+      "integrity": "sha512-5/VF9hcn5w7sYFOkI5QvmNm/bF7SrHgOWJzg8sC3d93oRvMSRFHY0nZLVcBnC3ntno9Ut3p5H+MdQGu/4H6RmQ==",
       "dev": true,
       "optional": true
     },
     "google-closure-compiler-windows": {
-      "version": "20250520.0.0",
-      "resolved": "https://registry.npmjs.org/google-closure-compiler-windows/-/google-closure-compiler-windows-20250520.0.0.tgz",
-      "integrity": "sha512-hKfXOixSZl7Dk1epXtwh6yCTQBwSgE70DcuYboYjyMicOr2/bTL3m1+i0YoiQX6NWBsrrCK1D602Ua9tih/F3A==",
+      "version": "20260302.0.0",
+      "resolved": "https://registry.npmjs.org/google-closure-compiler-windows/-/google-closure-compiler-windows-20260302.0.0.tgz",
+      "integrity": "sha512-V1EI7/GTvtYAcedI0Ol8dNGnHHdcQR672xoO80HhG/l3yCftxLJO6tB+Jlvw8UOgyYYkuhXHg9f7HnsbrdTOlw==",
       "dev": true,
       "optional": true
     },

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "c8": "^10.1.3",
     "chai": "^5.2.0",
     "clickhouse": "^2.6.0",
-    "google-closure-compiler": "^20250520.0.0",
+    "google-closure-compiler": "^20260302.0.0",
     "mocha": "^11.1.0",
     "mongodb": "^6.13.0",
     "pg-promise": "^11.13.0",

--- a/src/type.js
+++ b/src/type.js
@@ -7,6 +7,23 @@ import WorkerIndex from "./worker.js";
 import Encoder from "./encoder.js";
 import StorageInterface from "./db/interface.js";
 
+// JSDoc type definitions for Closure Compiler (used when imports are stripped during build)
+/**
+ * @typedef {*} Index
+ */
+/**
+ * @typedef {*} Document
+ */
+/**
+ * @typedef {*} WorkerIndex
+ */
+/**
+ * @typedef {*} Encoder
+ */
+/**
+ * @typedef {*} StorageInterface
+ */
+
 /**
  * @typedef {{
  *   preset: (string|undefined),
@@ -235,7 +252,7 @@ export let EncoderSplitOptions = {};
  *   matcher: (Map<string, string>|undefined),
  *   mapper: (Map<string, string>|undefined),
  *   stemmer: (Map<string, string>|undefined),
- *   replacer: (Array<string|RegExp, string>|undefined),
+ *   replacer: (Array<*>|undefined),
  *   minlength: (number|undefined),
  *   maxlength: (number|undefined),
  *   cache: (boolean|undefined)

--- a/task/build.js
+++ b/task/build.js
@@ -195,13 +195,30 @@ if(release === "lang"){
                 //fs.copyFileSync("src/lang/" + lang + ".js", "tmp/lang/" + lang + ".js");
                 //console.log(lang)
 
-                content = fs.readFileSync("tmp/type.js", "utf8");
-                content = content.replace('import Index from "./index.js";', '')
-                                 .replace('import WorkerIndex from "./worker.js";', '')
-                                 .replace('import Document from "./document.js";', '')
-                                 .replace('import Encoder from "./encoder.js";', '')
-                                 .replace('import StorageInterface from "./db/interface.js";', '');
-                fs.writeFileSync("tmp/type.js", content);
+                // Only modify tmp/type.js on the first iteration
+                if (x === 0) {
+                    content = fs.readFileSync("tmp/type.js", "utf8");
+                    // Remove imports
+                    content = content.replace('import Index from "./index.js";', '')
+                        .replace('import WorkerIndex from "./worker.js";', '')
+                        .replace('import Document from "./document.js";', '')
+                        .replace('import Encoder from "./encoder.js";', '')
+                        .replace('import StorageInterface from "./db/interface.js";', '');
+                    // Remove the JSDoc typedefs for exported types if they exist (from source file)
+                    content = content.replace(/\/\/ JSDoc type definitions for Closure Compiler.*\n/g, '')
+                        .replace(/\/\*\*\n \* @typedef \{\*?\} Index\n \*\/\n/g, '')
+                        .replace(/\/\*\*\n \* @typedef \{\*?\} Document\n \*\/\n/g, '')
+                        .replace(/\/\*\*\n \* @typedef \{\*?\} WorkerIndex\n \*\/\n/g, '')
+                        .replace(/\/\*\*\n \* @typedef \{\*?\} Encoder\n \*\/\n/g, '')
+                        .replace(/\/\*\*\n \* @typedef \{\*?\} StorageInterface\n \*\/\n/g, '');
+                    // Replace type references with Object or * to avoid "Unknown type" warnings
+                    content = content.replace(/\(Encoder\|/g, '(Object|')
+                        .replace(/\(StorageInterface\|/g, '(Object|')
+                        .replace(/\(Index\|/g, '(Object|')
+                        .replace(/Document\|/g, 'Object|')
+                        .replace(/WorkerIndex\|/g, 'Object|');
+                    fs.writeFileSync("tmp/type.js", content);
+                }
 
                 fs.writeFileSync("tmp/lang.js", `
                     import { EncoderOptions, EncoderSplitOptions } from "./type.js";


### PR DESCRIPTION
This pull request improves compatibility with the Google Closure Compiler and addresses type handling in the build process. The main changes include updating the compiler dependency, adding and later stripping JSDoc typedefs, and refining type references to prevent build warnings.

Dependency update:

* Updated the `google-closure-compiler` dependency in `package.json` to the latest version for improved compatibility and bug fixes.

Type definitions and build process enhancements:

* Added JSDoc typedefs for key types (`Index`, `Document`, `WorkerIndex`, `Encoder`, `StorageInterface`) in `src/type.js` to provide type information for Closure Compiler when imports are stripped.
* Modified the build script in `task/build.js` to automatically remove both imports and the newly added JSDoc typedefs from `tmp/type.js` during the build process, and to replace type references with `Object` or `*` to avoid Closure Compiler "Unknown type" warnings.

Type signature adjustment:

* Relaxed the type for the `replacer` property in the `EncoderSplitOptions` typedef to accept any array, improving flexibility and compatibility.